### PR TITLE
Add port overlap check for existing router groups

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,10 +27,11 @@ type OAuthConfig struct {
 }
 
 type Config struct {
-	OAuth             OAuthConfig      `yaml:"oauth"`
-	RoutingAPI        RoutingAPIConfig `yaml:"routing_api"`
-	HaProxyPidFile    string           `yaml:"haproxy_pid_file"`
-	IsolationSegments []string         `yaml:"isolation_segments"`
+	OAuth                        OAuthConfig      `yaml:"oauth"`
+	RoutingAPI                   RoutingAPIConfig `yaml:"routing_api"`
+	HaProxyPidFile               string           `yaml:"haproxy_pid_file"`
+	IsolationSegments            []string         `yaml:"isolation_segments"`
+	ReservedSystemComponentPorts []int            `yaml:"reserved_system_component_ports"`
 }
 
 func New(path string) (*Config, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,8 +28,9 @@ var _ = Describe("Config", func() {
 					ClientPrivateKeyPath:  "/b/private_key",
 					CACertificatePath:     "/c/ca_cert",
 				},
-				HaProxyPidFile:    "/path/to/pid/file",
-				IsolationSegments: []string{"foo-iso-seg"},
+				HaProxyPidFile:               "/path/to/pid/file",
+				IsolationSegments:            []string{"foo-iso-seg"},
+				ReservedSystemComponentPorts: []int{8080, 8081},
 			}
 			cfg, err := config.New("fixtures/valid_config.yml")
 			Expect(err).NotTo(HaveOccurred())

--- a/config/fixtures/valid_config.yml
+++ b/config/fixtures/valid_config.yml
@@ -16,3 +16,4 @@ routing_api:
 
 haproxy_pid_file: /path/to/pid/file
 isolation_segments: ["foo-iso-seg"]
+reserved_system_component_ports: [8080, 8081]

--- a/main_suite_test.go
+++ b/main_suite_test.go
@@ -248,8 +248,9 @@ func getRouterGroupGuid(routingApiClient routing_api.Client) string {
 	return routerGroups[0].Guid
 }
 
-func generateTCPRouterConfigFile(oauthServerPort int, uaaCACertsPath string, routingApiAuthDisabled bool) string {
+func generateTCPRouterConfigFile(oauthServerPort int, uaaCACertsPath string, routingApiAuthDisabled bool, reserved_routing_ports ...int) string {
 	tcpRouterConfig := config.Config{
+		ReservedSystemComponentPorts: reserved_routing_ports,
 		OAuth: config.OAuthConfig{
 			TokenEndpoint:     "127.0.0.1",
 			SkipSSLValidation: false,

--- a/router_group_port_checker/router_group_port_checker.go
+++ b/router_group_port_checker/router_group_port_checker.go
@@ -1,0 +1,94 @@
+package router_group_port_checker
+
+import (
+	routing_api "code.cloudfoundry.org/routing-api"
+	"code.cloudfoundry.org/routing-api/models"
+	uaaclient "code.cloudfoundry.org/uaa-go-client"
+	"code.cloudfoundry.org/uaa-go-client/schema"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type PortChecker struct {
+	routingAPIClient routing_api.Client
+	uaaClient        uaaclient.Client
+}
+
+func NewPortChecker(routingAPIClient routing_api.Client, uaaClient uaaclient.Client) PortChecker {
+	return PortChecker{
+		routingAPIClient: routingAPIClient,
+		uaaClient:        uaaClient,
+	}
+}
+
+func (pc *PortChecker) Check(systemComponentPorts []int) (bool, error) {
+	routerGroups, err := pc.getRouterGroups()
+	if err != nil {
+		return false, err
+	}
+	shouldExit, portErrors := validateRouterGroups(routerGroups, systemComponentPorts)
+
+	if len(portErrors) == 0 {
+		return false, nil
+	}
+
+	return shouldExit, errors.New(strings.Join(portErrors, "\n"))
+}
+
+func (pc *PortChecker) getRouterGroups() ([]models.RouterGroup, error) {
+	var err error
+	numRetries := 3
+
+	for i := 0; i < numRetries; i++ {
+		var token *schema.Token
+		token, err = pc.uaaClient.FetchToken(false)
+		if err != nil {
+			continue
+		}
+		pc.routingAPIClient.SetToken(token.AccessToken)
+		break
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("error-fetching-uaa-token: \"%s\"", err.Error())
+	}
+
+	for i := 0; i < numRetries; i++ {
+		var routerGroups []models.RouterGroup
+		routerGroups, err = pc.routingAPIClient.RouterGroups()
+		if err == nil {
+			return routerGroups, nil
+		}
+	}
+	return nil, fmt.Errorf("error-fetching-routing-groups: \"%s\"", err.Error())
+}
+
+func validateRouterGroups(routerGroups []models.RouterGroup, systemComponentPorts []int) (bool, []string) {
+	var errors []string
+	shouldExit := false
+
+	for _, group := range routerGroups {
+		reservablePorts := group.ReservablePorts
+		ranges, _ := reservablePorts.Parse()
+		for _, r := range ranges {
+			start, end := r.Endpoints()
+
+			overlappingPorts := []string{}
+			for _, portInt := range systemComponentPorts {
+				port := uint64(portInt)
+				if port >= start && port <= end {
+					overlappingPorts = append(overlappingPorts, strconv.FormatUint(port, 10))
+				}
+			}
+
+			if len(overlappingPorts) > 0 {
+				shouldExit = true
+				formattedPorts := strings.Join(overlappingPorts, ", ")
+				errors = append(errors, fmt.Sprintf("The reserved ports for router group '%v' contains the following reserved system component port(s): '%v'. Please update your router group accordingly.", group.Name, formattedPorts))
+			}
+		}
+	}
+	return shouldExit, errors
+}

--- a/router_group_port_checker/router_group_port_checker_suite_test.go
+++ b/router_group_port_checker/router_group_port_checker_suite_test.go
@@ -1,0 +1,13 @@
+package router_group_port_checker_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRouterGroupPortChecker(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RouterGroupPortChecker Suite")
+}

--- a/router_group_port_checker/router_group_port_checker_test.go
+++ b/router_group_port_checker/router_group_port_checker_test.go
@@ -1,0 +1,158 @@
+package router_group_port_checker_test
+
+import (
+	"errors"
+
+	"code.cloudfoundry.org/routing-api/fake_routing_api"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"code.cloudfoundry.org/cf-tcp-router/router_group_port_checker"
+	"code.cloudfoundry.org/routing-api/models"
+	testUaaClient "code.cloudfoundry.org/uaa-go-client/fakes"
+	"code.cloudfoundry.org/uaa-go-client/schema"
+)
+
+var _ = Describe("RouterGroupPortChecker", func() {
+	var (
+		fakeRoutingApiClient       *fake_routing_api.FakeClient
+		fakeUaaClient              *testUaaClient.FakeClient
+		token                      *schema.Token
+		routerGroup1, routerGroup2 models.RouterGroup
+	)
+	BeforeEach(func() {
+
+		fakeRoutingApiClient = new(fake_routing_api.FakeClient)
+		fakeUaaClient = &testUaaClient.FakeClient{}
+		token = &schema.Token{
+			AccessToken: "access_token",
+			ExpiresIn:   5,
+		}
+		routerGroup1 = models.RouterGroup{
+			Name:            "router-group-1",
+			Type:            "tcp",
+			ReservablePorts: "1024-2000",
+		}
+		routerGroup2 = models.RouterGroup{
+			Name:            "router-group-2",
+			Type:            "tcp",
+			ReservablePorts: "2001-2048",
+		}
+
+	})
+	It("doesn't return an error when there is no overlaps and should not exit", func() {
+		fakeUaaClient.FetchTokenReturns(token, nil)
+		fakeRoutingApiClient.RouterGroupsReturns([]models.RouterGroup{routerGroup1}, nil)
+		checker := router_group_port_checker.NewPortChecker(fakeRoutingApiClient, fakeUaaClient)
+		shouldExit, err := checker.Check([]int{2048})
+
+		Expect(fakeRoutingApiClient.SetTokenArgsForCall(0)).To(Equal(token.AccessToken))
+		Expect(err).To(BeNil())
+		Expect(shouldExit).To(BeFalse())
+	})
+
+	It("Returns an error when there is an overlap and should exit", func() {
+		fakeUaaClient.FetchTokenReturns(token, nil)
+		fakeRoutingApiClient.RouterGroupsReturns([]models.RouterGroup{routerGroup1}, nil)
+		checker := router_group_port_checker.NewPortChecker(fakeRoutingApiClient, fakeUaaClient)
+		shouldExit, err := checker.Check([]int{1026})
+
+		Expect(fakeRoutingApiClient.SetTokenArgsForCall(0)).To(Equal(token.AccessToken))
+
+		msg := "The reserved ports for router group 'router-group-1' contains the following reserved system component port(s): '1026'. Please update your router group accordingly."
+		Expect(err).To(MatchError(msg))
+		Expect(shouldExit).To(BeTrue())
+	})
+
+	It("Returns multiple errors when there is multiple overlaps and should exit", func() {
+		fakeUaaClient.FetchTokenReturns(token, nil)
+		fakeRoutingApiClient.RouterGroupsReturns([]models.RouterGroup{routerGroup1, routerGroup2}, nil)
+		checker := router_group_port_checker.NewPortChecker(fakeRoutingApiClient, fakeUaaClient)
+		shouldExit, err := checker.Check([]int{1026, 1027, 2001, 2002})
+
+		Expect(fakeRoutingApiClient.SetTokenArgsForCall(0)).To(Equal(token.AccessToken))
+
+		msg := "The reserved ports for router group 'router-group-1' contains the following reserved system component port(s): '1026, 1027'. Please update your router group accordingly.\n"
+		msg = msg + "The reserved ports for router group 'router-group-2' contains the following reserved system component port(s): '2001, 2002'. Please update your router group accordingly."
+
+		Expect(err).To(MatchError(msg))
+		Expect(shouldExit).To(BeTrue())
+	})
+
+	Context("when routing api requires retries", func() {
+		Context("but eventually works", func() {
+			BeforeEach(func() {
+				fakeUaaClient.FetchTokenReturns(token, nil)
+				fakeRoutingApiClient.RouterGroupsReturnsOnCall(0, []models.RouterGroup{}, errors.New("oh no!"))
+				fakeRoutingApiClient.RouterGroupsReturnsOnCall(1, []models.RouterGroup{}, errors.New("oh no!"))
+				fakeRoutingApiClient.RouterGroupsReturnsOnCall(2, []models.RouterGroup{routerGroup1}, nil)
+			})
+
+			It("doesn't error when there is no overlap and should not exit", func() {
+				checker := router_group_port_checker.NewPortChecker(fakeRoutingApiClient, fakeUaaClient)
+				shouldExit, err := checker.Check([]int{2048})
+				Expect(err).To(BeNil())
+				Expect(shouldExit).To(BeFalse())
+			})
+
+			It("returns an error when there is an overlap and should exit", func() {
+				checker := router_group_port_checker.NewPortChecker(fakeRoutingApiClient, fakeUaaClient)
+				shouldExit, err := checker.Check([]int{1026})
+				msg := "The reserved ports for router group 'router-group-1' contains the following reserved system component port(s): '1026'. Please update your router group accordingly."
+				Expect(err).To(MatchError(msg))
+				Expect(shouldExit).To(BeTrue())
+			})
+		})
+
+		Context("and always fails", func() {
+			BeforeEach(func() {
+				fakeUaaClient.FetchTokenReturns(token, nil)
+				fakeRoutingApiClient.RouterGroupsReturns([]models.RouterGroup{}, errors.New("oh no!"))
+			})
+
+			It("returns an error and should not exit", func() {
+				checker := router_group_port_checker.NewPortChecker(fakeRoutingApiClient, fakeUaaClient)
+				shouldExit, err := checker.Check([]int{})
+				Expect(err).To(MatchError("error-fetching-routing-groups: \"oh no!\""))
+				Expect(shouldExit).To(BeFalse())
+			})
+		})
+	})
+
+	Context("when fetch token requires retries", func() {
+		Context("but eventually works", func() {
+			BeforeEach(func() {
+				fakeUaaClient.FetchTokenReturnsOnCall(0, nil, errors.New("oh no!"))
+				fakeUaaClient.FetchTokenReturnsOnCall(1, nil, errors.New("oh no!"))
+				fakeUaaClient.FetchTokenReturnsOnCall(2, token, nil)
+				fakeRoutingApiClient.RouterGroupsReturns([]models.RouterGroup{routerGroup1}, nil)
+			})
+
+			It("doesn't error when there is no overlap and should not exit", func() {
+				checker := router_group_port_checker.NewPortChecker(fakeRoutingApiClient, fakeUaaClient)
+				shouldExit, err := checker.Check([]int{2048})
+				Expect(err).To(BeNil())
+				Expect(shouldExit).To(BeFalse())
+			})
+
+			It("returns an error when there is an overlap and should exit", func() {
+				checker := router_group_port_checker.NewPortChecker(fakeRoutingApiClient, fakeUaaClient)
+				shouldExit, err := checker.Check([]int{1026})
+				msg := "The reserved ports for router group 'router-group-1' contains the following reserved system component port(s): '1026'. Please update your router group accordingly."
+				Expect(err).To(MatchError(msg))
+				Expect(shouldExit).To(BeTrue())
+			})
+		})
+		Context("and always fails", func() {
+			BeforeEach(func() {
+				fakeUaaClient.FetchTokenReturns(nil, errors.New("oh no!"))
+			})
+			It("returns an error and should not exit", func() {
+				checker := router_group_port_checker.NewPortChecker(fakeRoutingApiClient, fakeUaaClient)
+				shouldExit, err := checker.Check([]int{})
+				Expect(err).To(MatchError("error-fetching-uaa-token: \"oh no!\""))
+				Expect(shouldExit).To(BeFalse())
+			})
+		})
+	})
+})

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -2,6 +2,7 @@ package testrunner
 
 import (
 	"os/exec"
+	"strconv"
 	"time"
 
 	"github.com/tedsuo/ifrit/ginkgomon"
@@ -12,6 +13,7 @@ type Args struct {
 	BaseLoadBalancerConfigFilePath string
 	LoadBalancerConfigFilePath     string
 	ConfigFilePath                 string
+	RoutingGroupCheckExit          bool
 }
 
 func (args Args) ArgSlice() []string {
@@ -23,6 +25,7 @@ func (args Args) ArgSlice() []string {
 		"-tokenFetchRetryInterval", "1s",
 		"-staleRouteCheckInterval", "5s",
 		"-logLevel=debug",
+		"-routingGroupCheckExit=" + strconv.FormatBool(args.RoutingGroupCheckExit),
 	}
 }
 


### PR DESCRIPTION
* prevent router groups from claiming system component ports
* runtime check and deploy time check
* if existing router groups include system component ports then you can
set the config to make the deploy fail
* even if the deploy is not set to fail, it will log when ports overlap
* see docs for more info: https://github.com/cloudfoundry/routing-release/commit/83448037836e6f81a0afe3fdef2b2ac5bbf33c7d
* fixes this issue: https://github.com/cloudfoundry/routing-release/issues/184

[#176681696](https://www.pivotaltracker.com/story/show/176681696)

Co-authored-by: Ben Fuller <benjaminf@vmware.com>
Co-authored-by: Kaitlin Barrer <kbarrer@vmware.com>
Co-authored-by: Renee Chu <reneec@vmware.com>