### PR TITLE
[#184642652] Selectively reload haproxy during bulk-syncs with cached…

### DIFF
--- a/models/routing_table_test.go
+++ b/models/routing_table_test.go
@@ -1,8 +1,9 @@
 package models_test
 
 import (
-	"code.cloudfoundry.org/lager"
 	"time"
+
+	"code.cloudfoundry.org/lager"
 
 	"code.cloudfoundry.org/cf-tcp-router/models"
 	"code.cloudfoundry.org/cf-tcp-router/testutil"
@@ -714,7 +715,7 @@ var _ = Describe("RoutingTable", func() {
 		})
 
 		JustBeforeEach(func() {
-			routingTableEntry.PruneBackends(defaultTTL)
+			routingTableEntry.PruneBackends(defaultTTL, logger)
 		})
 
 		Context("when it has expired backends", func() {


### PR DESCRIPTION
… events

Previously cf-tcp-router would *always* reload haproxy if it detected cached events during its bulk-sync. However, the majority of the time, these cached events were simply route-registration heartbeats, with no functional changes requiring an haproxy reload.

Because haproxy reloads keep previous processes open to gracefully handle long-lived TCP connections, this resulted in many haproxy instances stacking up over time.

Now bulk-syncer looks at the state of the cached changes, and only updates the config if they modified the routing table, using the same logic that the HandleEvent() calls use.