### PR TITLE
Genericize locket setup for postgres too

### DIFF
--- a/main_suite_test.go
+++ b/main_suite_test.go
@@ -227,7 +227,14 @@ var _ = SynchronizedAfterSuite(func() {
 
 func setupLocket() {
 	locketRunner := testrunner.NewLocketRunner(locketBinPath, func(c *locket_config.LocketConfig) {
-		c.DatabaseConnectionString = "root:password@/" + locketDbConfig.Schema
+		switch os.Getenv("DB") {
+		case "postgres":
+			c.DatabaseConnectionString = "user=postgres password= host=localhost dbname=" + locketDbConfig.Schema
+			c.DatabaseDriver = "postgres"
+		default:
+			c.DatabaseConnectionString = "root:password@/" + locketDbConfig.Schema
+			c.DatabaseDriver = "mysql"
+		}
 		c.ListenAddress = fmt.Sprintf("localhost:%d", locketPort)
 	})
 	locketProcess = ginkgomon.Invoke(locketRunner)


### PR DESCRIPTION
This was currently hardcoded to assume a mysql server. This changes that to allow a postgres server to be used with locket when running the tests.

[#182691815](https://www.pivotaltracker.com/story/show/182691815)