### PR TITLE
Update to use newer signature for NewTcpRouteMapping function

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Main", func() {
 				ConfigFilePath:                 configFile,
 			}
 
-			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-1", 61000, 120)
+			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-1", 61000, 0, "", nil, 120, models.ModificationTag{})
 			err := routingApiClient.UpsertTcpRouteMappings([]models.TcpRouteMapping{tcpRouteMapping})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -176,7 +176,7 @@ var _ = Describe("Main", func() {
 		It("starts an SSE connection to the server", func() {
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("Subscribing-to-routing-api-event-stream"))
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("Successfully-subscribed-to-routing-api-event-stream"))
-			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-2", 61000, 120)
+			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-2", 61000, 0, "", nil, 120, models.ModificationTag{})
 			err := routingApiClient.UpsertTcpRouteMappings([]models.TcpRouteMapping{tcpRouteMapping})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("handle-event.finished"))
@@ -191,7 +191,7 @@ var _ = Describe("Main", func() {
 		It("prunes stale routes", func() {
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("Subscribing-to-routing-api-event-stream"))
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("Successfully-subscribed-to-routing-api-event-stream"))
-			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-3", 61000, 6)
+			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-3", 61000, 0, "", nil, 6, models.ModificationTag{})
 			err := routingApiClient.UpsertTcpRouteMappings([]models.TcpRouteMapping{tcpRouteMapping})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("handle-event.finished"))
@@ -342,7 +342,7 @@ var _ = Describe("Main", func() {
 			server = routingApiServer(logger)
 			routerGroupGuid = getRouterGroupGuid(routingApiClient)
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("Successfully-subscribed-to-routing-api-event-stream"))
-			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-3", 61000, 120)
+			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-3", 61000, 0, "", nil, 120, models.ModificationTag{})
 			err := routingApiClient.UpsertTcpRouteMappings([]models.TcpRouteMapping{tcpRouteMapping})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("handle-event.finished"))

--- a/routing_table/updater_test.go
+++ b/routing_table/updater_test.go
@@ -95,11 +95,14 @@ var _ = Describe("Updater", func() {
 		Context("when Upsert event is received", func() {
 			Context("when entry does not exist", func() {
 				BeforeEach(func() {
-					mapping := apimodels.NewTcpRouteMappingWithModificationTag(
+					mapping := apimodels.NewTcpRouteMapping(
 						routerGroupGuid,
 						externalPort4,
 						"some-ip-4",
 						2346,
+						0,
+						"",
+						nil,
 						ttl,
 						modificationTag,
 					)
@@ -134,11 +137,14 @@ var _ = Describe("Updater", func() {
 
 				Context("an existing backend is provided", func() {
 					BeforeEach(func() {
-						mapping := apimodels.NewTcpRouteMappingWithModificationTag(
+						mapping := apimodels.NewTcpRouteMapping(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-1",
 							1234,
+							0,
+							"",
+							nil,
 							newTTL,
 							newModificationTag,
 						)
@@ -164,11 +170,14 @@ var _ = Describe("Updater", func() {
 
 				Context("and a new backend is provided", func() {
 					BeforeEach(func() {
-						mapping := apimodels.NewTcpRouteMappingWithModificationTag(
+						mapping := apimodels.NewTcpRouteMapping(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-5",
 							1234,
+							0,
+							"",
+							nil,
 							ttl,
 							newModificationTag,
 						)
@@ -216,11 +225,14 @@ var _ = Describe("Updater", func() {
 
 			Context("when entry does not exist", func() {
 				BeforeEach(func() {
-					mapping := apimodels.NewTcpRouteMappingWithModificationTag(
+					mapping := apimodels.NewTcpRouteMapping(
 						routerGroupGuid,
 						externalPort4,
 						"some-ip-4",
 						2346,
+						0,
+						"",
+						nil,
 						ttl,
 						newModificationTag,
 					)
@@ -253,11 +265,14 @@ var _ = Describe("Updater", func() {
 							},
 						)
 						Expect(routingTable.Set(existingRoutingKey5, existingRoutingTableEntry5)).To(BeTrue())
-						mapping := apimodels.NewTcpRouteMappingWithModificationTag(
+						mapping := apimodels.NewTcpRouteMapping(
 							routerGroupGuid,
 							externalPort5,
 							"some-ip-1",
 							1234,
+							0,
+							"",
+							nil,
 							ttl,
 							modificationTag,
 						)
@@ -306,11 +321,14 @@ var _ = Describe("Updater", func() {
 						)
 						Expect(routingTable.Set(existingRoutingKey6, existingRoutingTableEntry6)).To(BeTrue())
 
-						mapping := apimodels.NewTcpRouteMappingWithModificationTag(
+						mapping := apimodels.NewTcpRouteMapping(
 							routerGroupGuid,
 							externalPort5,
 							"some-ip-5",
 							1234,
+							0,
+							"",
+							nil,
 							ttl,
 							newModificationTag,
 						)
@@ -352,35 +370,47 @@ var _ = Describe("Updater", func() {
 		BeforeEach(func() {
 			doneChannel = make(chan struct{})
 			tcpMappings = []apimodels.TcpRouteMapping{
-				apimodels.NewTcpRouteMappingWithModificationTag(
+				apimodels.NewTcpRouteMapping(
 					routerGroupGuid,
 					externalPort1,
 					"some-ip-1",
 					61000,
+					0,
+					"",
+					nil,
 					ttl,
 					modificationTag,
 				),
-				apimodels.NewTcpRouteMappingWithModificationTag(
+				apimodels.NewTcpRouteMapping(
 					routerGroupGuid,
 					externalPort1,
 					"some-ip-2",
 					61001,
+					0,
+					"",
+					nil,
 					ttl,
 					modificationTag,
 				),
-				apimodels.NewTcpRouteMappingWithModificationTag(
+				apimodels.NewTcpRouteMapping(
 					routerGroupGuid,
 					externalPort2,
 					"some-ip-3",
 					60000,
+					0,
+					"",
+					nil,
 					ttl,
 					modificationTag,
 				),
-				apimodels.NewTcpRouteMappingWithModificationTag(
+				apimodels.NewTcpRouteMapping(
 					routerGroupGuid,
 					externalPort2,
 					"some-ip-4",
 					60000,
+					0,
+					"",
+					nil,
 					ttl,
 					modificationTag,
 				),
@@ -451,19 +481,25 @@ var _ = Describe("Updater", func() {
 			Context("when things have been deleted from the table", func() {
 				BeforeEach(func() {
 					tcpMappings = []apimodels.TcpRouteMapping{
-						apimodels.NewTcpRouteMappingWithModificationTag(
+						apimodels.NewTcpRouteMapping(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-1",
 							61000,
+							0,
+							"",
+							nil,
 							ttl,
 							modificationTag,
 						),
-						apimodels.NewTcpRouteMappingWithModificationTag(
+						apimodels.NewTcpRouteMapping(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-2",
 							61001,
+							0,
+							"",
+							nil,
 							ttl,
 							modificationTag,
 						),
@@ -528,11 +564,14 @@ var _ = Describe("Updater", func() {
 						go invokeSync(doneChannel)
 						Eventually(updater.Syncing).Should(BeTrue())
 						tcpEvent = routing_api.TcpEvent{
-							TcpRouteMapping: apimodels.NewTcpRouteMappingWithModificationTag(
+							TcpRouteMapping: apimodels.NewTcpRouteMapping(
 								routerGroupGuid,
 								externalPort1,
 								"some-ip-2",
 								61001,
+								0,
+								"",
+								nil,
 								0,
 								modificationTag,
 							),
@@ -565,11 +604,14 @@ var _ = Describe("Updater", func() {
 					go invokeSync(doneChannel)
 					Eventually(updater.Syncing).Should(BeTrue())
 					tcpEvent = routing_api.TcpEvent{
-						TcpRouteMapping: apimodels.NewTcpRouteMappingWithModificationTag(
+						TcpRouteMapping: apimodels.NewTcpRouteMapping(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-2",
 							61001,
+							0,
+							"",
+							nil,
 							0,
 							modificationTag,
 						),
@@ -650,11 +692,14 @@ var _ = Describe("Updater", func() {
 							newModificationTag := modificationTag
 							newModificationTag.Increment()
 							tcpEvent = routing_api.TcpEvent{
-								TcpRouteMapping: apimodels.NewTcpRouteMappingWithModificationTag(
+								TcpRouteMapping: apimodels.NewTcpRouteMapping(
 									routerGroupGuid,
 									externalPort1,
 									"some-ip-1",
 									61000,
+									0,
+									"",
+									nil,
 									22,
 									apimodels.ModificationTag{Guid: "guid-1", Index: 1},
 								),
@@ -685,11 +730,14 @@ var _ = Describe("Updater", func() {
 							Eventually(updater.Syncing).Should(BeTrue())
 							// submit an event while syncing
 							tcpEvent = routing_api.TcpEvent{
-								TcpRouteMapping: apimodels.NewTcpRouteMappingWithModificationTag(
+								TcpRouteMapping: apimodels.NewTcpRouteMapping(
 									routerGroupGuid,
 									externalPort1,
 									"some-ip-22",
 									61001,
+									0,
+									"",
+									nil,
 									22,
 									newModificationTag,
 								),
@@ -718,8 +766,8 @@ var _ = Describe("Updater", func() {
 					existingRoutingKey1 = models.RoutingKey{Port: externalPort1}
 					existingRoutingTableEntry1 = models.NewRoutingTableEntry(
 						[]models.BackendServerInfo{
-							models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
-							models.BackendServerInfo{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
 						},
 					)
 					Expect(routingTable.Set(existingRoutingKey1, existingRoutingTableEntry1)).To(BeTrue())
@@ -735,8 +783,8 @@ var _ = Describe("Updater", func() {
 					Expect(routingTable.Size()).To(Equal(1))
 					expectedRoutingTableEntry1 := models.NewRoutingTableEntry(
 						[]models.BackendServerInfo{
-							models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
-							models.BackendServerInfo{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
 						},
 					)
 					verifyRoutingTableEntry(models.RoutingKey{Port: externalPort1}, expectedRoutingTableEntry1)
@@ -749,8 +797,8 @@ var _ = Describe("Updater", func() {
 					existingRoutingKey1 = models.RoutingKey{Port: externalPort1}
 					existingRoutingTableEntry1 = models.NewRoutingTableEntry(
 						[]models.BackendServerInfo{
-							models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
-							models.BackendServerInfo{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
 						},
 					)
 					Expect(routingTable.Set(existingRoutingKey1, existingRoutingTableEntry1)).To(BeTrue())
@@ -770,8 +818,8 @@ var _ = Describe("Updater", func() {
 					Expect(routingTable.Size()).To(Equal(1))
 					expectedRoutingTableEntry1 := models.NewRoutingTableEntry(
 						[]models.BackendServerInfo{
-							models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
-							models.BackendServerInfo{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
 						},
 					)
 					verifyRoutingTableEntry(models.RoutingKey{Port: externalPort1}, expectedRoutingTableEntry1)
@@ -785,8 +833,8 @@ var _ = Describe("Updater", func() {
 				existingRoutingKey1 = models.RoutingKey{Port: externalPort1}
 				existingRoutingTableEntry1 = models.NewRoutingTableEntry(
 					[]models.BackendServerInfo{
-						models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
-						models.BackendServerInfo{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+						{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+						{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
 					},
 				)
 				Expect(routingTable.Set(existingRoutingKey1, existingRoutingTableEntry1)).To(BeTrue())
@@ -802,8 +850,8 @@ var _ = Describe("Updater", func() {
 				Expect(routingTable.Size()).To(Equal(1))
 				expectedRoutingTableEntry1 := models.NewRoutingTableEntry(
 					[]models.BackendServerInfo{
-						models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
-						models.BackendServerInfo{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+						{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+						{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
 					},
 				)
 				verifyRoutingTableEntry(models.RoutingKey{Port: externalPort1}, expectedRoutingTableEntry1)
@@ -850,15 +898,15 @@ var _ = Describe("Updater", func() {
 				Expect(routingTable.Size()).To(Equal(2))
 				expectedRoutingTableEntry1 := models.NewRoutingTableEntry(
 					[]models.BackendServerInfo{
-						models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag},
-						models.BackendServerInfo{Address: "some-ip-2", Port: 1235, ModificationTag: modificationTag},
+						{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag},
+						{Address: "some-ip-2", Port: 1235, ModificationTag: modificationTag},
 					},
 				)
 				verifyRoutingTableEntry(models.RoutingKey{Port: externalPort1}, expectedRoutingTableEntry1)
 				expectedRoutingTableEntry2 := models.NewRoutingTableEntry(
 					[]models.BackendServerInfo{
-						models.BackendServerInfo{Address: "some-ip-3", Port: 1234, ModificationTag: modificationTag},
-						models.BackendServerInfo{Address: "some-ip-4", Port: 1235, ModificationTag: modificationTag},
+						{Address: "some-ip-3", Port: 1234, ModificationTag: modificationTag},
+						{Address: "some-ip-4", Port: 1235, ModificationTag: modificationTag},
 					},
 				)
 				verifyRoutingTableEntry(models.RoutingKey{Port: externalPort2}, expectedRoutingTableEntry2)
@@ -877,8 +925,8 @@ var _ = Describe("Updater", func() {
 				Expect(routingTable.Size()).To(Equal(1))
 				expectedRoutingTableEntry2 := models.NewRoutingTableEntry(
 					[]models.BackendServerInfo{
-						models.BackendServerInfo{Address: "some-ip-3", Port: 1234, ModificationTag: modificationTag},
-						models.BackendServerInfo{Address: "some-ip-4", Port: 1235, ModificationTag: modificationTag},
+						{Address: "some-ip-3", Port: 1234, ModificationTag: modificationTag},
+						{Address: "some-ip-4", Port: 1235, ModificationTag: modificationTag},
 					},
 				)
 				verifyRoutingTableEntry(models.RoutingKey{Port: externalPort2}, expectedRoutingTableEntry2)

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -72,6 +72,10 @@ var _ = Describe("Watcher", func() {
 					"some-ip-1",
 					5222,
 					0,
+					"",
+					nil,
+					0,
+					models.ModificationTag{},
 				),
 				Action: "Upsert",
 			}
@@ -98,6 +102,10 @@ var _ = Describe("Watcher", func() {
 					"some-ip-1",
 					5222,
 					0,
+					"",
+					nil,
+					0,
+					models.ModificationTag{},
 				),
 				Action: "Delete",
 			}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

Updates cf-tcp-router code to handle the new routing-api models + generator function for TCP routes.

Backward Compatibility
---------------
Breaking Change? **Yes/No**

No