### PR TITLE
Revert "Update to use newer signature for NewTcpRouteMapping function…

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Main", func() {
 				ConfigFilePath:                 configFile,
 			}
 
-			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-1", 61000, 0, "", nil, 120, models.ModificationTag{})
+			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-1", 61000, 120)
 			err := routingApiClient.UpsertTcpRouteMappings([]models.TcpRouteMapping{tcpRouteMapping})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -176,7 +176,7 @@ var _ = Describe("Main", func() {
 		It("starts an SSE connection to the server", func() {
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("Subscribing-to-routing-api-event-stream"))
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("Successfully-subscribed-to-routing-api-event-stream"))
-			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-2", 61000, 0, "", nil, 120, models.ModificationTag{})
+			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-2", 61000, 120)
 			err := routingApiClient.UpsertTcpRouteMappings([]models.TcpRouteMapping{tcpRouteMapping})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("handle-event.finished"))
@@ -191,7 +191,7 @@ var _ = Describe("Main", func() {
 		It("prunes stale routes", func() {
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("Subscribing-to-routing-api-event-stream"))
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("Successfully-subscribed-to-routing-api-event-stream"))
-			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-3", 61000, 0, "", nil, 6, models.ModificationTag{})
+			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-3", 61000, 6)
 			err := routingApiClient.UpsertTcpRouteMappings([]models.TcpRouteMapping{tcpRouteMapping})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("handle-event.finished"))
@@ -342,7 +342,7 @@ var _ = Describe("Main", func() {
 			server = routingApiServer(logger)
 			routerGroupGuid = getRouterGroupGuid(routingApiClient)
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("Successfully-subscribed-to-routing-api-event-stream"))
-			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-3", 61000, 0, "", nil, 120, models.ModificationTag{})
+			tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-3", 61000, 120)
 			err := routingApiClient.UpsertTcpRouteMappings([]models.TcpRouteMapping{tcpRouteMapping})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session.Out, 5*time.Second).Should(gbytes.Say("handle-event.finished"))

--- a/routing_table/updater_test.go
+++ b/routing_table/updater_test.go
@@ -95,14 +95,11 @@ var _ = Describe("Updater", func() {
 		Context("when Upsert event is received", func() {
 			Context("when entry does not exist", func() {
 				BeforeEach(func() {
-					mapping := apimodels.NewTcpRouteMapping(
+					mapping := apimodels.NewTcpRouteMappingWithModificationTag(
 						routerGroupGuid,
 						externalPort4,
 						"some-ip-4",
 						2346,
-						0,
-						"",
-						nil,
 						ttl,
 						modificationTag,
 					)
@@ -137,14 +134,11 @@ var _ = Describe("Updater", func() {
 
 				Context("an existing backend is provided", func() {
 					BeforeEach(func() {
-						mapping := apimodels.NewTcpRouteMapping(
+						mapping := apimodels.NewTcpRouteMappingWithModificationTag(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-1",
 							1234,
-							0,
-							"",
-							nil,
 							newTTL,
 							newModificationTag,
 						)
@@ -170,14 +164,11 @@ var _ = Describe("Updater", func() {
 
 				Context("and a new backend is provided", func() {
 					BeforeEach(func() {
-						mapping := apimodels.NewTcpRouteMapping(
+						mapping := apimodels.NewTcpRouteMappingWithModificationTag(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-5",
 							1234,
-							0,
-							"",
-							nil,
 							ttl,
 							newModificationTag,
 						)
@@ -225,14 +216,11 @@ var _ = Describe("Updater", func() {
 
 			Context("when entry does not exist", func() {
 				BeforeEach(func() {
-					mapping := apimodels.NewTcpRouteMapping(
+					mapping := apimodels.NewTcpRouteMappingWithModificationTag(
 						routerGroupGuid,
 						externalPort4,
 						"some-ip-4",
 						2346,
-						0,
-						"",
-						nil,
 						ttl,
 						newModificationTag,
 					)
@@ -265,14 +253,11 @@ var _ = Describe("Updater", func() {
 							},
 						)
 						Expect(routingTable.Set(existingRoutingKey5, existingRoutingTableEntry5)).To(BeTrue())
-						mapping := apimodels.NewTcpRouteMapping(
+						mapping := apimodels.NewTcpRouteMappingWithModificationTag(
 							routerGroupGuid,
 							externalPort5,
 							"some-ip-1",
 							1234,
-							0,
-							"",
-							nil,
 							ttl,
 							modificationTag,
 						)
@@ -321,14 +306,11 @@ var _ = Describe("Updater", func() {
 						)
 						Expect(routingTable.Set(existingRoutingKey6, existingRoutingTableEntry6)).To(BeTrue())
 
-						mapping := apimodels.NewTcpRouteMapping(
+						mapping := apimodels.NewTcpRouteMappingWithModificationTag(
 							routerGroupGuid,
 							externalPort5,
 							"some-ip-5",
 							1234,
-							0,
-							"",
-							nil,
 							ttl,
 							newModificationTag,
 						)
@@ -370,47 +352,35 @@ var _ = Describe("Updater", func() {
 		BeforeEach(func() {
 			doneChannel = make(chan struct{})
 			tcpMappings = []apimodels.TcpRouteMapping{
-				apimodels.NewTcpRouteMapping(
+				apimodels.NewTcpRouteMappingWithModificationTag(
 					routerGroupGuid,
 					externalPort1,
 					"some-ip-1",
 					61000,
-					0,
-					"",
-					nil,
 					ttl,
 					modificationTag,
 				),
-				apimodels.NewTcpRouteMapping(
+				apimodels.NewTcpRouteMappingWithModificationTag(
 					routerGroupGuid,
 					externalPort1,
 					"some-ip-2",
 					61001,
-					0,
-					"",
-					nil,
 					ttl,
 					modificationTag,
 				),
-				apimodels.NewTcpRouteMapping(
+				apimodels.NewTcpRouteMappingWithModificationTag(
 					routerGroupGuid,
 					externalPort2,
 					"some-ip-3",
 					60000,
-					0,
-					"",
-					nil,
 					ttl,
 					modificationTag,
 				),
-				apimodels.NewTcpRouteMapping(
+				apimodels.NewTcpRouteMappingWithModificationTag(
 					routerGroupGuid,
 					externalPort2,
 					"some-ip-4",
 					60000,
-					0,
-					"",
-					nil,
 					ttl,
 					modificationTag,
 				),
@@ -481,25 +451,19 @@ var _ = Describe("Updater", func() {
 			Context("when things have been deleted from the table", func() {
 				BeforeEach(func() {
 					tcpMappings = []apimodels.TcpRouteMapping{
-						apimodels.NewTcpRouteMapping(
+						apimodels.NewTcpRouteMappingWithModificationTag(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-1",
 							61000,
-							0,
-							"",
-							nil,
 							ttl,
 							modificationTag,
 						),
-						apimodels.NewTcpRouteMapping(
+						apimodels.NewTcpRouteMappingWithModificationTag(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-2",
 							61001,
-							0,
-							"",
-							nil,
 							ttl,
 							modificationTag,
 						),
@@ -564,14 +528,11 @@ var _ = Describe("Updater", func() {
 						go invokeSync(doneChannel)
 						Eventually(updater.Syncing).Should(BeTrue())
 						tcpEvent = routing_api.TcpEvent{
-							TcpRouteMapping: apimodels.NewTcpRouteMapping(
+							TcpRouteMapping: apimodels.NewTcpRouteMappingWithModificationTag(
 								routerGroupGuid,
 								externalPort1,
 								"some-ip-2",
 								61001,
-								0,
-								"",
-								nil,
 								0,
 								modificationTag,
 							),
@@ -604,14 +565,11 @@ var _ = Describe("Updater", func() {
 					go invokeSync(doneChannel)
 					Eventually(updater.Syncing).Should(BeTrue())
 					tcpEvent = routing_api.TcpEvent{
-						TcpRouteMapping: apimodels.NewTcpRouteMapping(
+						TcpRouteMapping: apimodels.NewTcpRouteMappingWithModificationTag(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-2",
 							61001,
-							0,
-							"",
-							nil,
 							0,
 							modificationTag,
 						),
@@ -692,14 +650,11 @@ var _ = Describe("Updater", func() {
 							newModificationTag := modificationTag
 							newModificationTag.Increment()
 							tcpEvent = routing_api.TcpEvent{
-								TcpRouteMapping: apimodels.NewTcpRouteMapping(
+								TcpRouteMapping: apimodels.NewTcpRouteMappingWithModificationTag(
 									routerGroupGuid,
 									externalPort1,
 									"some-ip-1",
 									61000,
-									0,
-									"",
-									nil,
 									22,
 									apimodels.ModificationTag{Guid: "guid-1", Index: 1},
 								),
@@ -730,14 +685,11 @@ var _ = Describe("Updater", func() {
 							Eventually(updater.Syncing).Should(BeTrue())
 							// submit an event while syncing
 							tcpEvent = routing_api.TcpEvent{
-								TcpRouteMapping: apimodels.NewTcpRouteMapping(
+								TcpRouteMapping: apimodels.NewTcpRouteMappingWithModificationTag(
 									routerGroupGuid,
 									externalPort1,
 									"some-ip-22",
 									61001,
-									0,
-									"",
-									nil,
 									22,
 									newModificationTag,
 								),
@@ -766,8 +718,8 @@ var _ = Describe("Updater", func() {
 					existingRoutingKey1 = models.RoutingKey{Port: externalPort1}
 					existingRoutingTableEntry1 = models.NewRoutingTableEntry(
 						[]models.BackendServerInfo{
-							{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
-							{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							models.BackendServerInfo{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
 						},
 					)
 					Expect(routingTable.Set(existingRoutingKey1, existingRoutingTableEntry1)).To(BeTrue())
@@ -783,8 +735,8 @@ var _ = Describe("Updater", func() {
 					Expect(routingTable.Size()).To(Equal(1))
 					expectedRoutingTableEntry1 := models.NewRoutingTableEntry(
 						[]models.BackendServerInfo{
-							{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
-							{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							models.BackendServerInfo{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
 						},
 					)
 					verifyRoutingTableEntry(models.RoutingKey{Port: externalPort1}, expectedRoutingTableEntry1)
@@ -797,8 +749,8 @@ var _ = Describe("Updater", func() {
 					existingRoutingKey1 = models.RoutingKey{Port: externalPort1}
 					existingRoutingTableEntry1 = models.NewRoutingTableEntry(
 						[]models.BackendServerInfo{
-							{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
-							{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							models.BackendServerInfo{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
 						},
 					)
 					Expect(routingTable.Set(existingRoutingKey1, existingRoutingTableEntry1)).To(BeTrue())
@@ -818,8 +770,8 @@ var _ = Describe("Updater", func() {
 					Expect(routingTable.Size()).To(Equal(1))
 					expectedRoutingTableEntry1 := models.NewRoutingTableEntry(
 						[]models.BackendServerInfo{
-							{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
-							{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+							models.BackendServerInfo{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
 						},
 					)
 					verifyRoutingTableEntry(models.RoutingKey{Port: externalPort1}, expectedRoutingTableEntry1)
@@ -833,8 +785,8 @@ var _ = Describe("Updater", func() {
 				existingRoutingKey1 = models.RoutingKey{Port: externalPort1}
 				existingRoutingTableEntry1 = models.NewRoutingTableEntry(
 					[]models.BackendServerInfo{
-						{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
-						{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+						models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+						models.BackendServerInfo{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
 					},
 				)
 				Expect(routingTable.Set(existingRoutingKey1, existingRoutingTableEntry1)).To(BeTrue())
@@ -850,8 +802,8 @@ var _ = Describe("Updater", func() {
 				Expect(routingTable.Size()).To(Equal(1))
 				expectedRoutingTableEntry1 := models.NewRoutingTableEntry(
 					[]models.BackendServerInfo{
-						{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
-						{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+						models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
+						models.BackendServerInfo{Address: "some-ip-2", Port: 1234, ModificationTag: modificationTag, TTL: ttl},
 					},
 				)
 				verifyRoutingTableEntry(models.RoutingKey{Port: externalPort1}, expectedRoutingTableEntry1)
@@ -898,15 +850,15 @@ var _ = Describe("Updater", func() {
 				Expect(routingTable.Size()).To(Equal(2))
 				expectedRoutingTableEntry1 := models.NewRoutingTableEntry(
 					[]models.BackendServerInfo{
-						{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag},
-						{Address: "some-ip-2", Port: 1235, ModificationTag: modificationTag},
+						models.BackendServerInfo{Address: "some-ip-1", Port: 1234, ModificationTag: modificationTag},
+						models.BackendServerInfo{Address: "some-ip-2", Port: 1235, ModificationTag: modificationTag},
 					},
 				)
 				verifyRoutingTableEntry(models.RoutingKey{Port: externalPort1}, expectedRoutingTableEntry1)
 				expectedRoutingTableEntry2 := models.NewRoutingTableEntry(
 					[]models.BackendServerInfo{
-						{Address: "some-ip-3", Port: 1234, ModificationTag: modificationTag},
-						{Address: "some-ip-4", Port: 1235, ModificationTag: modificationTag},
+						models.BackendServerInfo{Address: "some-ip-3", Port: 1234, ModificationTag: modificationTag},
+						models.BackendServerInfo{Address: "some-ip-4", Port: 1235, ModificationTag: modificationTag},
 					},
 				)
 				verifyRoutingTableEntry(models.RoutingKey{Port: externalPort2}, expectedRoutingTableEntry2)
@@ -925,8 +877,8 @@ var _ = Describe("Updater", func() {
 				Expect(routingTable.Size()).To(Equal(1))
 				expectedRoutingTableEntry2 := models.NewRoutingTableEntry(
 					[]models.BackendServerInfo{
-						{Address: "some-ip-3", Port: 1234, ModificationTag: modificationTag},
-						{Address: "some-ip-4", Port: 1235, ModificationTag: modificationTag},
+						models.BackendServerInfo{Address: "some-ip-3", Port: 1234, ModificationTag: modificationTag},
+						models.BackendServerInfo{Address: "some-ip-4", Port: 1235, ModificationTag: modificationTag},
 					},
 				)
 				verifyRoutingTableEntry(models.RoutingKey{Port: externalPort2}, expectedRoutingTableEntry2)

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -72,10 +72,6 @@ var _ = Describe("Watcher", func() {
 					"some-ip-1",
 					5222,
 					0,
-					"",
-					nil,
-					0,
-					models.ModificationTag{},
 				),
 				Action: "Upsert",
 			}
@@ -102,10 +98,6 @@ var _ = Describe("Watcher", func() {
 					"some-ip-1",
 					5222,
 					0,
-					"",
-					nil,
-					0,
-					models.ModificationTag{},
 				),
 				Action: "Delete",
 			}


### PR DESCRIPTION
… (#17)"

This reverts commit ad527758638ded7f4d37669ae5cfdaf966c013a0.

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
