### PR TITLE
Add TLS/mTLS support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -74,10 +74,11 @@ func (c *Config) initConfigFromFile(path string) error {
 		if err != nil {
 			return err
 		}
-		for len(pemData) > 0 {
-			pemData = []byte(strings.TrimSpace(string(pemData)))
+
+		pemData = []byte(strings.TrimSpace(string(pemData)))
+		if len(pemData) > 0 {
 			var block *pem.Block
-			block, pemData = pem.Decode(pemData)
+			block, _ = pem.Decode(pemData)
 			if block == nil {
 				return fmt.Errorf("Invalid PEM block found in file %q", c.BackendTLS.CACertificatePath)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,14 @@
 package config
 
 import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
+	"fmt"
 	"os"
+	"strings"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -26,12 +32,18 @@ type OAuthConfig struct {
 	CACerts           string `yaml:"ca_certs"`
 }
 
+type BackendTLSConfig struct {
+	CACertificatePath    string `yaml:"ca_cert_path"`
+	ClientCertAndKeyPath string `yaml:"client_cert_and_key_path"`
+}
+
 type Config struct {
 	OAuth                        OAuthConfig      `yaml:"oauth"`
 	RoutingAPI                   RoutingAPIConfig `yaml:"routing_api"`
 	HaProxyPidFile               string           `yaml:"haproxy_pid_file"`
 	IsolationSegments            []string         `yaml:"isolation_segments"`
 	ReservedSystemComponentPorts []int            `yaml:"reserved_system_component_ports"`
+	BackendTLS                   BackendTLSConfig `yaml:"backend_tls"`
 }
 
 func New(path string) (*Config, error) {
@@ -56,5 +68,71 @@ func (c *Config) initConfigFromFile(path string) error {
 	if c.HaProxyPidFile == "" {
 		return errors.New("haproxy_pid_file is required")
 	}
+
+	if c.BackendTLS.CACertificatePath != "" {
+		pemData, err := os.ReadFile(c.BackendTLS.CACertificatePath)
+		if err != nil {
+			return err
+		}
+		for len(pemData) > 0 {
+			pemData = []byte(strings.TrimSpace(string(pemData)))
+			var block *pem.Block
+			block, pemData = pem.Decode(pemData)
+			if block == nil {
+				return fmt.Errorf("Invalid PEM block found in file %q", c.BackendTLS.CACertificatePath)
+			}
+			if len(block.Headers) != 0 {
+				return fmt.Errorf("Unexpected headers in PEM block in file %q: %v", c.BackendTLS.CACertificatePath, block.Headers)
+			}
+			if block.Type != "CERTIFICATE" {
+				return fmt.Errorf("Unexpected PEM block type %q in file %q (wanted CERTIFICATE)", block.Type, c.BackendTLS.CACertificatePath)
+			}
+			_, err = x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return fmt.Errorf("failed to parse certificate in %q: %s", c.BackendTLS.CACertificatePath, err)
+			}
+		}
+	}
+
+	if c.BackendTLS.ClientCertAndKeyPath != "" {
+		pemData, err := os.ReadFile(c.BackendTLS.ClientCertAndKeyPath)
+		if err != nil {
+			return err
+		}
+
+		pemData = []byte(strings.TrimSpace(string(pemData)))
+		var certBlock *pem.Block
+		certBlock, pemData = pem.Decode(pemData)
+		if certBlock == nil {
+			return fmt.Errorf("Invalid PEM CERTIFICATE found in file %q", c.BackendTLS.ClientCertAndKeyPath)
+		}
+		certPEM := bytes.NewBuffer([]byte{})
+		err = pem.Encode(certPEM, certBlock)
+		if err != nil {
+			return fmt.Errorf("Could not encode cert as PEM data: %s", err)
+		}
+
+		pemData = []byte(strings.TrimSpace(string(pemData)))
+		var keyBlock *pem.Block
+		keyBlock, pemData = pem.Decode(pemData)
+		if keyBlock == nil {
+			return fmt.Errorf("Invalid PEM PRIVATE KEY found in file %q", c.BackendTLS.ClientCertAndKeyPath)
+		}
+		keyPEM := bytes.NewBuffer([]byte{})
+		err = pem.Encode(keyPEM, keyBlock)
+		if err != nil {
+			return fmt.Errorf("Could not encode key as PEM data: %s", err)
+		}
+
+		if len(pemData) > 0 {
+			return fmt.Errorf("Unexpected data at the end of %s", c.BackendTLS.ClientCertAndKeyPath)
+		}
+
+		_, err = tls.X509KeyPair(certPEM.Bytes(), keyPEM.Bytes())
+		if err != nil {
+			return fmt.Errorf("Unable to validate backend TLS client cert + key in file %q: %s", c.BackendTLS.ClientCertAndKeyPath, err)
+		}
+	}
+
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -108,6 +108,7 @@ var _ = Describe("Config", func() {
 		It("returns an error", func() {
 			_, err := config.New("fixtures/bad_ca_config.yml")
 			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Invalid PEM block found in file"))
 		})
 	})
 
@@ -115,6 +116,7 @@ var _ = Describe("Config", func() {
 		It("returns an error", func() {
 			_, err := config.New("fixtures/bad_client_cert_config.yml")
 			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Invalid PEM CERTIFICATE found in file"))
 		})
 	})
 
@@ -122,6 +124,8 @@ var _ = Describe("Config", func() {
 		It("returns an error", func() {
 			_, err := config.New("fixtures/mismatched_client_cert_config.yml")
 			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Unable to validate backend TLS client cert + key in file"))
+			Expect(err.Error()).To(ContainSubstring("tls: private key does not match public key"))
 		})
 	})
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,12 +1,59 @@
 package config_test
 
 import (
+	"fmt"
+	"os"
+
+	tlshelpers "code.cloudfoundry.org/cf-routing-test-helpers/tls"
 	"code.cloudfoundry.org/cf-tcp-router/config"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Config", func() {
+	caFile := "fixtures/ca.pem"
+	certAndKeyFile := "fixtures/cert_and_key.pem"
+	mismatchedCertAndKeyFile := "fixtures/mismatched_cert_and_key.pem"
+
+	BeforeEach(func() {
+		// Generate a CA and move it into the correct location for the fixture
+		tmpCAFile, _ := tlshelpers.GenerateCa()
+		err := os.Rename(tmpCAFile, caFile)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Generate a second trusted CA and add it to the fixture's CA file
+		tmpCAFile2, _ := tlshelpers.GenerateCa()
+		caBytes, err := os.ReadFile(tmpCAFile2)
+		Expect(err).ToNot(HaveOccurred())
+		f, err := os.OpenFile(caFile, os.O_RDWR|os.O_APPEND, 0644)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = f.Write(caBytes)
+		Expect(err).ToNot(HaveOccurred())
+		err = os.Remove(tmpCAFile2)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Generate a client cert + key, and move it into the correct location for the fixture
+		_, tmpCertFile1, tmpKeyFile1, _ := tlshelpers.GenerateCaAndMutualTlsCerts()
+		cert1Bytes, err := os.ReadFile(tmpCertFile1)
+		Expect(err).NotTo(HaveOccurred())
+		key1Bytes, err := os.ReadFile(tmpKeyFile1)
+		Expect(err).NotTo(HaveOccurred())
+		os.WriteFile(certAndKeyFile, []byte(fmt.Sprintf("%s%s", string(cert1Bytes), string(key1Bytes))), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Generate a second client cert + key, and move it into the correct location for the fixture
+		// used for the invalid key-pair combo to fail if a key and cert do not go together
+		_, _, tmpKeyFile2, _ := tlshelpers.GenerateCaAndMutualTlsCerts()
+		key2Bytes, err := os.ReadFile(tmpKeyFile2)
+		Expect(err).NotTo(HaveOccurred())
+		os.WriteFile(mismatchedCertAndKeyFile, []byte(fmt.Sprintf("%s%s", string(cert1Bytes), string(key2Bytes))), 0644)
+		Expect(err).NotTo(HaveOccurred())
+	})
+	AfterEach(func() {
+		os.Remove(caFile)
+		os.Remove(certAndKeyFile)
+		os.Remove(mismatchedCertAndKeyFile)
+	})
 
 	Context("when a valid config", func() {
 		It("loads the config", func() {
@@ -31,6 +78,10 @@ var _ = Describe("Config", func() {
 				HaProxyPidFile:               "/path/to/pid/file",
 				IsolationSegments:            []string{"foo-iso-seg"},
 				ReservedSystemComponentPorts: []int{8080, 8081},
+				BackendTLS: config.BackendTLSConfig{
+					CACertificatePath:    caFile,
+					ClientCertAndKeyPath: certAndKeyFile,
+				},
 			}
 			cfg, err := config.New("fixtures/valid_config.yml")
 			Expect(err).NotTo(HaveOccurred())
@@ -50,6 +101,27 @@ var _ = Describe("Config", func() {
 				_, err := config.New("fixtures/malformed_config.yml")
 				Expect(err).To(HaveOccurred())
 			})
+		})
+	})
+
+	Context("when the CA path is not a valid CA", func() {
+		It("returns an error", func() {
+			_, err := config.New("fixtures/bad_ca_config.yml")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("when the Client Cert/key pair are not valid", func() {
+		It("returns an error", func() {
+			_, err := config.New("fixtures/bad_client_cert_config.yml")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("when the Client Cert/key pair are mismatched", func() {
+		It("returns an error", func() {
+			_, err := config.New("fixtures/mismatched_client_cert_config.yml")
+			Expect(err).To(HaveOccurred())
 		})
 	})
 

--- a/config/fixtures/bad_ca.pem
+++ b/config/fixtures/bad_ca.pem
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+meowpotato
+-----END CERTIFICATE-----

--- a/config/fixtures/bad_ca_config.yml
+++ b/config/fixtures/bad_ca_config.yml
@@ -18,5 +18,4 @@ haproxy_pid_file: /path/to/pid/file
 isolation_segments: ["foo-iso-seg"]
 reserved_system_component_ports: [8080, 8081]
 backend_tls:
-  ca_cert_path: fixtures/ca.pem
-  client_cert_and_key_path: fixtures/cert_and_key.pem
+  ca_cert_path: fixtures/bad_ca.pem

--- a/config/fixtures/bad_cert_and_key.pem
+++ b/config/fixtures/bad_cert_and_key.pem
@@ -1,0 +1,6 @@
+-----BEGIN CERTIFICATE-----
+meowpotato
+-----END CERTIFICATE-----
+-----BEGIN BEGIN PRIVATE KEY-----
+meowpotato
+-----END BEGIN PRIVATE KEY-----

--- a/config/fixtures/bad_client_cert_config.yml
+++ b/config/fixtures/bad_client_cert_config.yml
@@ -19,4 +19,4 @@ isolation_segments: ["foo-iso-seg"]
 reserved_system_component_ports: [8080, 8081]
 backend_tls:
   ca_cert_path: fixtures/ca.pem
-  client_cert_and_key_path: fixtures/cert_and_key.pem
+  client_cert_and_key_path: fixtures/bad_cert_and_key.pem

--- a/config/fixtures/mismatched_client_cert_config.yml
+++ b/config/fixtures/mismatched_client_cert_config.yml
@@ -19,4 +19,4 @@ isolation_segments: ["foo-iso-seg"]
 reserved_system_component_ports: [8080, 8081]
 backend_tls:
   ca_cert_path: fixtures/ca.pem
-  client_cert_and_key_path: fixtures/cert_and_key.pem
+  client_cert_and_key_path: fixtures/mismatched_cert_and_key.pem

--- a/configurer/configurer.go
+++ b/configurer/configurer.go
@@ -3,6 +3,7 @@ package configurer
 import (
 	"errors"
 
+	"code.cloudfoundry.org/cf-tcp-router/config"
 	"code.cloudfoundry.org/cf-tcp-router/configurer/haproxy"
 	"code.cloudfoundry.org/cf-tcp-router/models"
 	"code.cloudfoundry.org/cf-tcp-router/monitor"
@@ -18,16 +19,18 @@ type RouterConfigurer interface {
 	Configure(routingTable models.RoutingTable) error
 }
 
-func NewConfigurer(logger lager.Logger, tcpLoadBalancer string, tcpLoadBalancerBaseCfg string, tcpLoadBalancerCfg string, monitor monitor.Monitor, scriptRunner haproxy.ScriptRunner) RouterConfigurer {
+func NewConfigurer(logger lager.Logger, tcpLoadBalancer string, tcpLoadBalancerBaseCfg string, tcpLoadBalancerCfg string, monitor monitor.Monitor, scriptRunner haproxy.ScriptRunner, backendTlsCfg config.BackendTLSConfig) RouterConfigurer {
 	switch tcpLoadBalancer {
 	case HaProxyConfigurer:
 		routerHostInfo, err := haproxy.NewHaProxyConfigurer(
 			logger,
-			haproxy.NewConfigMarshaller(),
+			haproxy.NewConfigMarshaller(logger),
 			tcpLoadBalancerBaseCfg,
 			tcpLoadBalancerCfg,
 			monitor,
-			scriptRunner)
+			scriptRunner,
+			backendTlsCfg,
+		)
 
 		if err != nil {
 			logger.Fatal("could not create tcp load balancer",

--- a/configurer/configurer_test.go
+++ b/configurer/configurer_test.go
@@ -3,6 +3,8 @@ package configurer_test
 import (
 	"reflect"
 
+	tlshelpers "code.cloudfoundry.org/cf-routing-test-helpers/tls"
+	"code.cloudfoundry.org/cf-tcp-router/config"
 	"code.cloudfoundry.org/cf-tcp-router/configurer"
 	"code.cloudfoundry.org/cf-tcp-router/configurer/haproxy"
 
@@ -13,10 +15,20 @@ import (
 var _ = Describe("Configurer", func() {
 
 	Describe("NewConfigurer", func() {
+		var backendTlsCfg config.BackendTLSConfig
+		BeforeEach(func() {
+			caFile, _ := tlshelpers.GenerateCa()
+			_, clientCertFile, _, _ := tlshelpers.GenerateCaAndMutualTlsCerts()
+
+			backendTlsCfg = config.BackendTLSConfig{
+				CACertificatePath:    caFile,
+				ClientCertAndKeyPath: clientCertFile,
+			}
+		})
 		Context("when 'haproxy' tcp load balancer is passed", func() {
 			It("should return haproxy configurer", func() {
 				routeConfigurer := configurer.NewConfigurer(logger,
-					configurer.HaProxyConfigurer, "haproxy/fixtures/haproxy.cfg.template", "haproxy/fixtures/haproxy.cfg", nil, nil)
+					configurer.HaProxyConfigurer, "haproxy/fixtures/haproxy.cfg.template", "haproxy/fixtures/haproxy.cfg", nil, nil, backendTlsCfg)
 				Expect(routeConfigurer).ShouldNot(BeNil())
 				expectedType := reflect.PtrTo(reflect.TypeOf(haproxy.Configurer{}))
 				value := reflect.ValueOf(routeConfigurer)
@@ -26,7 +38,7 @@ var _ = Describe("Configurer", func() {
 			Context("when invalid config file is passed", func() {
 				It("should panic", func() {
 					Expect(func() {
-						configurer.NewConfigurer(logger, configurer.HaProxyConfigurer, "haproxy/fixtures/haproxy.cfg.template", "", nil, nil)
+						configurer.NewConfigurer(logger, configurer.HaProxyConfigurer, "haproxy/fixtures/haproxy.cfg.template", "", nil, nil, backendTlsCfg)
 					}).Should(Panic())
 				})
 			})
@@ -34,8 +46,31 @@ var _ = Describe("Configurer", func() {
 			Context("when invalid base config file is passed", func() {
 				It("should panic", func() {
 					Expect(func() {
-						configurer.NewConfigurer(logger, configurer.HaProxyConfigurer, "", "haproxy/fixtures/haproxy.cfg", nil, nil)
+						configurer.NewConfigurer(logger, configurer.HaProxyConfigurer, "", "haproxy/fixtures/haproxy.cfg", nil, nil, backendTlsCfg)
 					}).Should(Panic())
+				})
+			})
+
+			Context("when invalid CA file is passed", func() {
+				It("should panic", func() {
+					Expect(func() {
+						configurer.NewConfigurer(logger, configurer.HaProxyConfigurer, "haproxy/fixtures/haproxy.cfg.template", "haproxy/fixtures/haproxy.cfg", nil, nil, config.BackendTLSConfig{CACertificatePath: "nonexistent/file"})
+					}).Should(Panic())
+				})
+			})
+
+			Context("when invalid ClientCertAndKey file is passed", func() {
+				It("should panic", func() {
+					Expect(func() {
+						configurer.NewConfigurer(logger, configurer.HaProxyConfigurer, "haproxy/fixtures/haproxy.cfg.template", "haproxy/fixtures/haproxy.cfg", nil, nil, config.BackendTLSConfig{ClientCertAndKeyPath: "nonexistent/file"})
+					}).Should(Panic())
+				})
+			})
+			Context("when empty CA + ClientCertAndKey paths are passed", func() {
+				It("should not panic", func() {
+					Expect(func() {
+						configurer.NewConfigurer(logger, configurer.HaProxyConfigurer, "haproxy/fixtures/haproxy.cfg.template", "haproxy/fixtures/haproxy.cfg", nil, nil, config.BackendTLSConfig{})
+					}).ShouldNot(Panic())
 				})
 			})
 		})
@@ -43,7 +78,7 @@ var _ = Describe("Configurer", func() {
 		Context("when non-supported tcp load balancer is passed", func() {
 			It("should panic", func() {
 				Expect(func() {
-					configurer.NewConfigurer(logger, "not-supported", "some-base-config-file", "some-config-file", nil, nil)
+					configurer.NewConfigurer(logger, "not-supported", "some-base-config-file", "some-config-file", nil, nil, backendTlsCfg)
 				}).Should(Panic())
 			})
 		})
@@ -51,7 +86,7 @@ var _ = Describe("Configurer", func() {
 		Context("when empty tcp load balancer is passed", func() {
 			It("should panic", func() {
 				Expect(func() {
-					configurer.NewConfigurer(logger, "", "some-base-config-file", "some-config-file", nil, nil)
+					configurer.NewConfigurer(logger, "", "some-base-config-file", "some-config-file", nil, nil, backendTlsCfg)
 				}).Should(Panic())
 			})
 		})

--- a/configurer/haproxy/config_marshaller.go
+++ b/configurer/haproxy/config_marshaller.go
@@ -5,33 +5,37 @@ import (
 	"sort"
 	"strings"
 
+	"code.cloudfoundry.org/cf-tcp-router/config"
 	"code.cloudfoundry.org/cf-tcp-router/models"
+	"code.cloudfoundry.org/lager/v3"
 )
 
 //go:generate counterfeiter -o fakes/fake_config_marshaller.go . ConfigMarshaller
 type ConfigMarshaller interface {
-	Marshal(models.HAProxyConfig) string
+	Marshal(models.HAProxyConfig, config.BackendTLSConfig) string
 }
 
-type configMarshaller struct{}
-
-func NewConfigMarshaller() ConfigMarshaller {
-	return configMarshaller{}
+type configMarshaller struct {
+	logger lager.Logger
 }
 
-func (cm configMarshaller) Marshal(conf models.HAProxyConfig) string {
+func NewConfigMarshaller(l lager.Logger) ConfigMarshaller {
+	return configMarshaller{logger: l}
+}
+
+func (cm configMarshaller) Marshal(conf models.HAProxyConfig, backendTlsCfg config.BackendTLSConfig) string {
 	var output strings.Builder
 	sortedPorts := sortedHAProxyInboundPorts(conf)
 	for inboundPortIdx := range sortedPorts {
 		port := sortedPorts[inboundPortIdx]
 		frontend := conf[port]
 
-		output.WriteString(cm.marshalHAProxyFrontend(port, frontend))
+		output.WriteString(cm.marshalHAProxyFrontend(port, frontend, backendTlsCfg))
 	}
 	return output.String()
 }
 
-func (cm configMarshaller) marshalHAProxyFrontend(port models.HAProxyInboundPort, frontend models.HAProxyFrontend) string {
+func (cm configMarshaller) marshalHAProxyFrontend(port models.HAProxyInboundPort, frontend models.HAProxyFrontend, backendTlsCfg config.BackendTLSConfig) string {
 	var (
 		frontendStanza strings.Builder
 		backendStanzas strings.Builder
@@ -60,7 +64,9 @@ func (cm configMarshaller) marshalHAProxyFrontend(port models.HAProxyInboundPort
 		}
 
 		backend := frontend[hostname]
-		backendStanzas.WriteString(cm.marshalHAProxyBackend(backendCfgName, backend))
+
+		haProxyBackendString := cm.marshalHAProxyBackend(backendCfgName, backend, backendTlsCfg)
+		backendStanzas.WriteString(haProxyBackendString)
 	}
 
 	frontendStanza.WriteString("\n")
@@ -68,13 +74,32 @@ func (cm configMarshaller) marshalHAProxyFrontend(port models.HAProxyInboundPort
 	return frontendStanza.String()
 }
 
-func (cm configMarshaller) marshalHAProxyBackend(backendName string, backend models.HAProxyBackend) string {
+// This might result in malformed lines since we always write the opening stanza, but conditionally write others...
+func (cm configMarshaller) marshalHAProxyBackend(backendName string, backend models.HAProxyBackend, backendTlsCfg config.BackendTLSConfig) string {
 	var output strings.Builder
+
 	output.WriteString(fmt.Sprintf("\nbackend %s", backendName))
 	output.WriteString("\n  mode tcp")
 
 	for _, server := range backend {
-		output.WriteString(fmt.Sprintf("\n  server server_%s_%d %s:%d", server.Address, server.Port, server.Address, server.Port))
+		if server.TLSPort > 0 && backendTlsCfg.CACertificatePath == "" {
+			cm.logger.Error("route-missing-tls-information", fmt.Errorf("Backend TLS Port was set, but CA file path has not been configured"), lager.Data{"backend": backend})
+			//skip this endpoint, but there may be other backends with tlsport <= 0 that we should still set
+			continue
+		}
+
+		if server.TLSPort > 0 {
+			output.WriteString(fmt.Sprintf("\n  server server_%s_%d %s:%d ssl verify required verifyhost %s ca-file %s", server.Address, server.TLSPort, server.Address, server.TLSPort, server.InstanceID, backendTlsCfg.CACertificatePath))
+
+			if backendTlsCfg.ClientCertAndKeyPath != "" {
+				output.WriteString(fmt.Sprintf(" crt %s", backendTlsCfg.ClientCertAndKeyPath))
+			}
+		} else {
+			if server.TLSPort == 0 && backendTlsCfg.CACertificatePath != "" {
+				cm.logger.Error("route-missing-tls-information", fmt.Errorf("Backend TLSPort was set to 0. If TLS is intentionally off for this backend, set this to -1 to suppress this message"), lager.Data{"backend": server})
+			}
+			output.WriteString(fmt.Sprintf("\n  server server_%s_%d %s:%d", server.Address, server.Port, server.Address, server.Port))
+		}
 	}
 
 	output.WriteString("\n")

--- a/configurer/haproxy/fakes/fake_config_marshaller.go
+++ b/configurer/haproxy/fakes/fake_config_marshaller.go
@@ -4,15 +4,17 @@ package fakes
 import (
 	"sync"
 
+	"code.cloudfoundry.org/cf-tcp-router/config"
 	"code.cloudfoundry.org/cf-tcp-router/configurer/haproxy"
 	"code.cloudfoundry.org/cf-tcp-router/models"
 )
 
 type FakeConfigMarshaller struct {
-	MarshalStub        func(models.HAProxyConfig) string
+	MarshalStub        func(models.HAProxyConfig, config.BackendTLSConfig) string
 	marshalMutex       sync.RWMutex
 	marshalArgsForCall []struct {
 		arg1 models.HAProxyConfig
+		arg2 config.BackendTLSConfig
 	}
 	marshalReturns struct {
 		result1 string
@@ -24,18 +26,19 @@ type FakeConfigMarshaller struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeConfigMarshaller) Marshal(arg1 models.HAProxyConfig) string {
+func (fake *FakeConfigMarshaller) Marshal(arg1 models.HAProxyConfig, arg2 config.BackendTLSConfig) string {
 	fake.marshalMutex.Lock()
 	ret, specificReturn := fake.marshalReturnsOnCall[len(fake.marshalArgsForCall)]
 	fake.marshalArgsForCall = append(fake.marshalArgsForCall, struct {
 		arg1 models.HAProxyConfig
-	}{arg1})
+		arg2 config.BackendTLSConfig
+	}{arg1, arg2})
 	stub := fake.MarshalStub
 	fakeReturns := fake.marshalReturns
-	fake.recordInvocation("Marshal", []interface{}{arg1})
+	fake.recordInvocation("Marshal", []interface{}{arg1, arg2})
 	fake.marshalMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -49,17 +52,17 @@ func (fake *FakeConfigMarshaller) MarshalCallCount() int {
 	return len(fake.marshalArgsForCall)
 }
 
-func (fake *FakeConfigMarshaller) MarshalCalls(stub func(models.HAProxyConfig) string) {
+func (fake *FakeConfigMarshaller) MarshalCalls(stub func(models.HAProxyConfig, config.BackendTLSConfig) string) {
 	fake.marshalMutex.Lock()
 	defer fake.marshalMutex.Unlock()
 	fake.MarshalStub = stub
 }
 
-func (fake *FakeConfigMarshaller) MarshalArgsForCall(i int) models.HAProxyConfig {
+func (fake *FakeConfigMarshaller) MarshalArgsForCall(i int) (models.HAProxyConfig, config.BackendTLSConfig) {
 	fake.marshalMutex.RLock()
 	defer fake.marshalMutex.RUnlock()
 	argsForCall := fake.marshalArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeConfigMarshaller) MarshalReturns(result1 string) {

--- a/configurer/haproxy/haproxy_configurer.go
+++ b/configurer/haproxy/haproxy_configurer.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sync"
 
+	"code.cloudfoundry.org/cf-tcp-router/config"
 	"code.cloudfoundry.org/cf-tcp-router/models"
 	"code.cloudfoundry.org/cf-tcp-router/monitor"
 	"code.cloudfoundry.org/cf-tcp-router/utils"
@@ -14,6 +15,7 @@ import (
 
 const (
 	ErrRouterConfigFileNotFound = "Configuration file not found"
+	ErrRouterCAFileNotFound     = "CA file not found"
 )
 
 type Configurer struct {
@@ -22,23 +24,33 @@ type Configurer struct {
 	baseConfigFilePath string
 	configFilePath     string
 	configFileLock     *sync.Mutex
+	backendTlsCfg      config.BackendTLSConfig
 	monitor            monitor.Monitor
 	scriptRunner       ScriptRunner
 }
 
-func NewHaProxyConfigurer(logger lager.Logger, configMarshaller ConfigMarshaller, baseConfigFilePath string, configFilePath string, monitor monitor.Monitor, scriptRunner ScriptRunner) (*Configurer, error) {
+func NewHaProxyConfigurer(logger lager.Logger, configMarshaller ConfigMarshaller, baseConfigFilePath string, configFilePath string, monitor monitor.Monitor, scriptRunner ScriptRunner, backendTlsCfg config.BackendTLSConfig) (*Configurer, error) {
 	if !utils.FileExists(baseConfigFilePath) {
 		return nil, fmt.Errorf("%s: [%s]", ErrRouterConfigFileNotFound, baseConfigFilePath)
 	}
 	if !utils.FileExists(configFilePath) {
 		return nil, fmt.Errorf("%s: [%s]", ErrRouterConfigFileNotFound, configFilePath)
 	}
+	if backendTlsCfg.CACertificatePath != "" && !utils.FileExists(backendTlsCfg.CACertificatePath) {
+		return nil, fmt.Errorf("%s: [%s]", ErrRouterCAFileNotFound, backendTlsCfg.CACertificatePath)
+	}
+
+	if backendTlsCfg.ClientCertAndKeyPath != "" && !utils.FileExists(backendTlsCfg.ClientCertAndKeyPath) {
+		return nil, fmt.Errorf("%s: [%s]", ErrRouterCAFileNotFound, backendTlsCfg.ClientCertAndKeyPath)
+	}
+
 	return &Configurer{
 		logger:             logger,
 		configMarshaller:   configMarshaller,
 		baseConfigFilePath: baseConfigFilePath,
 		configFilePath:     configFilePath,
 		configFileLock:     new(sync.Mutex),
+		backendTlsCfg:      backendTlsCfg,
 		monitor:            monitor,
 		scriptRunner:       scriptRunner,
 	}, nil
@@ -67,7 +79,7 @@ func (h *Configurer) Configure(routingTable models.RoutingTable) error {
 	}
 
 	haproxyConf := models.NewHAProxyConfig(routingTable, h.logger)
-	marshalledConf := h.configMarshaller.Marshal(haproxyConf)
+	marshalledConf := h.configMarshaller.Marshal(haproxyConf, h.backendTlsCfg)
 
 	_, err = buff.Write([]byte(marshalledConf))
 	if err != nil {

--- a/configurer/haproxy/haproxy_suite_test.go
+++ b/configurer/haproxy/haproxy_suite_test.go
@@ -1,7 +1,6 @@
 package haproxy_test
 
 import (
-	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -10,7 +9,7 @@ import (
 )
 
 var (
-	logger lager.Logger
+	logger *lagertest.TestLogger
 )
 
 func TestHaproxy(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -171,6 +171,7 @@ func main() {
 		*tcpLoadBalancerCfg,
 		monitor,
 		reloaderRunner,
+		cfg.BackendTLS,
 	)
 
 	// Reap child processes to prevent zombies when running in a container (BPM)

--- a/models/haproxy_config.go
+++ b/models/haproxy_config.go
@@ -42,6 +42,12 @@ func NewHAProxyConfig(routingTable RoutingTable, logger lager.Logger) HAProxyCon
 				logError(logger, "backend_configuration.address", routingKey, backendKey.Address)
 				continue
 			}
+
+			if (backendKey.TLSPort > 0) && (backendKey.InstanceID == "") {
+				logError(logger, "backend_configuration.instance_id", routingKey, "unset")
+				continue
+			}
+
 			backends = append(backends, HAProxyServer(backendKey))
 		}
 

--- a/models/haproxy_config_test.go
+++ b/models/haproxy_config_test.go
@@ -6,6 +6,7 @@ import (
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("HAProxyConfig", func() {
@@ -113,6 +114,38 @@ var _ = Describe("HAProxyConfig", func() {
 						}))
 					})
 				})
+
+				Context("because backend TLS port is supplied but instance_id is not", func() {
+					It("logs an error", func() {
+						routingTable.Entries[RoutingKey{Port: 81}] = RoutingTableEntry{
+							Backends: map[BackendServerKey]BackendServerDetails{
+								BackendServerKey{Address: "valid-host-1.example.com", Port: 1111, TLSPort: 1443}: {},
+							},
+						}
+
+						Expect(NewHAProxyConfig(routingTable, logger)).To(Equal(HAProxyConfig{}))
+						Eventually(logger).Should(gbytes.Say(`Field: backend_configuration.instance_id. Value: unset.`))
+					})
+				})
+			})
+		})
+
+		Context("when TLS port and instance_id are provided", func() {
+			It("creates a valid HAProxyConfig", func() {
+				instanceId := "foo"
+				routingTable.Entries[RoutingKey{Port: 80}] = RoutingTableEntry{
+					Backends: map[BackendServerKey]BackendServerDetails{
+						BackendServerKey{Address: "valid-host-1.example.com", Port: 1111, TLSPort: 1443, InstanceID: instanceId}: {},
+					},
+				}
+
+				Expect(NewHAProxyConfig(routingTable, logger)).To(Equal(HAProxyConfig{
+					80: {
+						"": {
+							{Address: "valid-host-1.example.com", Port: 1111, TLSPort: 1443, InstanceID: instanceId},
+						},
+					},
+				}))
 			})
 		})
 

--- a/models/routing_table.go
+++ b/models/routing_table.go
@@ -19,13 +19,17 @@ type RoutingKey struct {
 type BackendServerInfo struct {
 	Address         string
 	Port            uint16
+	TLSPort         int
+	InstanceID      string
 	ModificationTag routing_api_models.ModificationTag
 	TTL             int
 }
 
 type BackendServerKey struct {
-	Address string
-	Port    uint16
+	Address    string
+	Port       uint16
+	TLSPort    int
+	InstanceID string
 }
 
 type BackendServerDetails struct {
@@ -48,7 +52,7 @@ func NewRoutingTableEntry(backends []BackendServerInfo) RoutingTableEntry {
 		Backends: make(map[BackendServerKey]BackendServerDetails),
 	}
 	for _, backend := range backends {
-		backendServerKey := BackendServerKey{Address: backend.Address, Port: backend.Port}
+		backendServerKey := BackendServerKey{Address: backend.Address, Port: backend.Port, TLSPort: backend.TLSPort, InstanceID: backend.InstanceID}
 		backendServerDetails := BackendServerDetails{ModificationTag: backend.ModificationTag, TTL: backend.TTL, UpdatedTime: time.Now()}
 
 		routingTableEntry.Backends[backendServerKey] = backendServerDetails
@@ -103,14 +107,15 @@ func (d BackendServerDetails) Expired(defaultTTL int) bool {
 	return expiryTime.After(d.UpdatedTime)
 }
 
-func NewBackendServerInfo(key BackendServerKey, detail BackendServerDetails) BackendServerInfo {
-	return BackendServerInfo{
-		Address:         key.Address,
-		Port:            key.Port,
-		ModificationTag: detail.ModificationTag,
-		TTL:             detail.TTL,
-	}
-}
+// WE THINK THIS IS NEVER USED. LET'S CONSIDER DELETING
+// func NewBackendServerInfo(key BackendServerKey, detail BackendServerDetails) BackendServerInfo {
+// 	return BackendServerInfo{
+// 		Address:         key.Address,
+// 		Port:            key.Port,
+// 		ModificationTag: detail.ModificationTag,
+// 		TTL:             detail.TTL,
+// 	}
+// }
 
 func (table RoutingTable) PruneEntries(defaultTTL int) {
 	for routeKey, entry := range table.Entries {
@@ -123,7 +128,7 @@ func (table RoutingTable) PruneEntries(defaultTTL int) {
 }
 
 func (table RoutingTable) serverKeyDetailsFromInfo(info BackendServerInfo) (BackendServerKey, BackendServerDetails) {
-	return BackendServerKey{Address: info.Address, Port: info.Port}, BackendServerDetails{ModificationTag: info.ModificationTag, TTL: info.TTL, UpdatedTime: time.Now()}
+	return BackendServerKey{Address: info.Address, Port: info.Port, TLSPort: info.TLSPort, InstanceID: info.InstanceID}, BackendServerDetails{ModificationTag: info.ModificationTag, TTL: info.TTL, UpdatedTime: time.Now()}
 }
 
 // Returns true if routing configuration should be modified, false if it should not.

--- a/models/routing_table.go
+++ b/models/routing_table.go
@@ -107,16 +107,6 @@ func (d BackendServerDetails) Expired(defaultTTL int) bool {
 	return expiryTime.After(d.UpdatedTime)
 }
 
-// WE THINK THIS IS NEVER USED. LET'S CONSIDER DELETING
-// func NewBackendServerInfo(key BackendServerKey, detail BackendServerDetails) BackendServerInfo {
-// 	return BackendServerInfo{
-// 		Address:         key.Address,
-// 		Port:            key.Port,
-// 		ModificationTag: detail.ModificationTag,
-// 		TTL:             detail.TTL,
-// 	}
-// }
-
 func (table RoutingTable) PruneEntries(defaultTTL int) {
 	for routeKey, entry := range table.Entries {
 		entry.PruneBackends(defaultTTL, table.logger)

--- a/models/routing_table_test.go
+++ b/models/routing_table_test.go
@@ -55,6 +55,26 @@ var _ = Describe("RoutingTable", func() {
 				Expect(routingTable.Get(routingKey)).To(Equal(routingTableEntry))
 				Expect(routingTable.Size()).To(Equal(1))
 			})
+
+			Context("when the entry has a TLSPort and InstanceID", func() {
+				BeforeEach(func() {
+					routingKey = models.RoutingKey{Port: 12}
+					backendServerKey = models.BackendServerKey{Address: "some-ip-1", Port: 1234, TLSPort: 61002, InstanceID: "meow-guid"}
+					now = time.Now()
+					backendServerDetails = models.BackendServerDetails{ModificationTag: modificationTag, TTL: 120, UpdatedTime: now}
+					backends := map[models.BackendServerKey]models.BackendServerDetails{
+						backendServerKey: backendServerDetails,
+					}
+					routingTableEntry = models.RoutingTableEntry{Backends: backends}
+				})
+
+				It("adds the entry", func() {
+					ok := routingTable.Set(routingKey, routingTableEntry)
+					Expect(ok).To(BeTrue())
+					Expect(routingTable.Get(routingKey)).To(Equal(routingTableEntry))
+					Expect(routingTable.Size()).To(Equal(1))
+				})
+			})
 		})
 
 		Context("when setting pre-existing routing key", func() {
@@ -65,8 +85,10 @@ var _ = Describe("RoutingTable", func() {
 
 			BeforeEach(func() {
 				newBackendServerKey = models.BackendServerKey{
-					Address: "some-ip-2",
-					Port:    1234,
+					Address:    "some-ip-2",
+					Port:       1234,
+					TLSPort:    5678,
+					InstanceID: "meow-guid",
 				}
 				existingRoutingTableEntry = models.RoutingTableEntry{
 					Backends: map[models.BackendServerKey]models.BackendServerDetails{
@@ -230,6 +252,29 @@ var _ = Describe("RoutingTable", func() {
 						testutil.RoutingTableEntryMatches(routingTable.Entries[newRoutingKey], existingRoutingTableEntry)
 					})
 				})
+			})
+		})
+
+		Context("when the BackendServerInfo contains a TLSPort", func() {
+			BeforeEach(func() {
+				existingRoutingKey = models.RoutingKey{Port: 80}
+				existingBackendServerInfo = models.BackendServerInfo{
+					Address:         "host-1.internal",
+					Port:            8080,
+					TLSPort:         8443,
+					InstanceID:      "meow",
+					ModificationTag: routing_api_models.ModificationTag{Guid: "11111111-1111-1111-1111-111111111111", Index: 2},
+					TTL:             60,
+				}
+				existingRoutingTableEntry = models.NewRoutingTableEntry([]models.BackendServerInfo{existingBackendServerInfo})
+			})
+
+			It("returns a RoutingTableEntry with a TLSPort and InstanceID", func() {
+				Expect(existingRoutingTableEntry.Backends).To(HaveLen(1))
+				for k, _ := range existingRoutingTableEntry.Backends {
+					Expect(k.TLSPort).To(Equal((8443)))
+					Expect(k.InstanceID).To(Equal("meow"))
+				}
 			})
 		})
 

--- a/routing_table/updater.go
+++ b/routing_table/updater.go
@@ -205,6 +205,8 @@ func (u *updater) toRoutingTableEntry(logger lager.Logger, routeMapping apimodel
 	backendServerInfo := models.BackendServerInfo{
 		Address:         routeMapping.HostIP,
 		Port:            routeMapping.HostPort,
+		TLSPort:         routeMapping.HostTLSPort,
+		InstanceID:      routeMapping.InstanceId,
 		ModificationTag: routeMapping.ModificationTag,
 		TTL:             ttl,
 	}
@@ -213,7 +215,6 @@ func (u *updater) toRoutingTableEntry(logger lager.Logger, routeMapping apimodel
 
 func (u *updater) handleUpsert(logger lager.Logger, routeMapping apimodels.TcpRouteMapping) (bool, error) {
 	routingKey, backendServerInfo := u.toRoutingTableEntry(logger, routeMapping)
-
 	tableChanged := u.routingTable.UpsertBackendServerKey(routingKey, backendServerInfo)
 	if tableChanged && !u.syncing {
 		logger.Debug("calling-configurer")

--- a/routing_table/updater_test.go
+++ b/routing_table/updater_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Updater", func() {
 	const (
 		externalPort1   = uint16(2222)
 		externalPort2   = uint16(2223)
+		externalPort3   = uint16(22233)
 		externalPort4   = uint16(2224)
 		externalPort5   = uint16(2225)
 		externalPort6   = uint16(2226)
@@ -36,6 +37,8 @@ var _ = Describe("Updater", func() {
 		existingRoutingTableEntry1 models.RoutingTableEntry
 		existingRoutingKey2        models.RoutingKey
 		existingRoutingTableEntry2 models.RoutingTableEntry
+		existingRoutingKey3        models.RoutingKey
+		existingRoutingTableEntry3 models.RoutingTableEntry
 		updater                    routing_table.Updater
 		fakeConfigurer             *fakes.FakeRouterConfigurer
 		fakeRoutingApiClient       *fake_routing_api.FakeClient
@@ -89,6 +92,15 @@ var _ = Describe("Updater", func() {
 			)
 			Expect(routingTable.Set(existingRoutingKey2, existingRoutingTableEntry2)).To(BeTrue())
 
+			existingRoutingKey3 = models.RoutingKey{Port: externalPort3}
+			existingRoutingTableEntry3 = models.NewRoutingTableEntry(
+				[]models.BackendServerInfo{
+					models.BackendServerInfo{Address: "some-ip-5", Port: 2346, ModificationTag: modificationTag, TTL: ttl, TLSPort: 61002, InstanceID: "meow-guid-1"},
+					models.BackendServerInfo{Address: "some-ip-6", Port: 2346, ModificationTag: modificationTag, TTL: ttl, TLSPort: 61002, InstanceID: "meow-guid-2"},
+				},
+			)
+			Expect(routingTable.Set(existingRoutingKey3, existingRoutingTableEntry3)).To(BeTrue())
+
 			updater = routing_table.NewUpdater(logger, routingTable, fakeConfigurer, fakeRoutingApiClient, fakeTokenFetcher, fakeClock, defaultTTL)
 		})
 
@@ -100,8 +112,8 @@ var _ = Describe("Updater", func() {
 						externalPort4,
 						"some-ip-4",
 						2346,
-						0,
-						"",
+						61002, // host tls port
+						"meow-instance-guid",
 						nil,
 						ttl,
 						modificationTag,
@@ -115,9 +127,10 @@ var _ = Describe("Updater", func() {
 				It("inserts handle the event and inserts the new entry", func() {
 					err := updater.HandleEvent(tcpEvent)
 					Expect(err).NotTo(HaveOccurred())
+					tlsPort := 61002
 					expectedRoutingTableEntry := models.NewRoutingTableEntry(
 						[]models.BackendServerInfo{
-							models.BackendServerInfo{Address: "some-ip-4", Port: 2346, TTL: ttl, ModificationTag: modificationTag},
+							models.BackendServerInfo{Address: "some-ip-4", Port: 2346, TTL: ttl, ModificationTag: modificationTag, TLSPort: tlsPort, InstanceID: "meow-instance-guid"},
 						},
 					)
 					verifyRoutingTableEntry(models.RoutingKey{Port: externalPort4}, expectedRoutingTableEntry)
@@ -165,6 +178,40 @@ var _ = Describe("Updater", func() {
 						)
 						verifyRoutingTableEntry(existingRoutingKey1, existingRoutingTableEntry)
 						Expect(fakeConfigurer.ConfigureCallCount()).To(Equal(0))
+					})
+
+					Context("when TLSPort and InstanceID are set", func() {
+						BeforeEach(func() {
+							mapping := apimodels.NewTcpRouteMapping(
+								routerGroupGuid,
+								externalPort3,
+								"some-ip-5",
+								2346,
+								61002,
+								"meow-guid-1",
+								nil,
+								newTTL,
+								newModificationTag,
+							)
+							tcpEvent = routing_api.TcpEvent{
+								TcpRouteMapping: mapping,
+								Action:          "Upsert",
+							}
+						})
+
+						It("does not call configurer", func() {
+							err := updater.HandleEvent(tcpEvent)
+							Expect(err).NotTo(HaveOccurred())
+							existingRoutingTableEntry := models.NewRoutingTableEntry(
+								[]models.BackendServerInfo{
+									models.BackendServerInfo{Address: "some-ip-5", Port: 2346, ModificationTag: newModificationTag, TTL: newTTL, TLSPort: 61002, InstanceID: "meow-guid-1"},
+									models.BackendServerInfo{Address: "some-ip-6", Port: 2346, ModificationTag: modificationTag, TTL: ttl, TLSPort: 61002, InstanceID: "meow-guid-2"},
+								},
+							)
+							verifyRoutingTableEntry(existingRoutingKey3, existingRoutingTableEntry)
+							Expect(fakeConfigurer.ConfigureCallCount()).To(Equal(0))
+						})
+
 					})
 				})
 
@@ -349,6 +396,50 @@ var _ = Describe("Updater", func() {
 						)
 						verifyRoutingTableEntry(existingRoutingKey6, expectedRoutingTableEntry)
 						Expect(fakeConfigurer.ConfigureCallCount()).To(Equal(0))
+					})
+				})
+
+				Context("TLSPort and InstanceID are provided", func() {
+					var (
+						existingRoutingKey5        models.RoutingKey
+						existingRoutingTableEntry5 models.RoutingTableEntry
+					)
+					BeforeEach(func() {
+						existingRoutingKey5 = models.RoutingKey{Port: externalPort5}
+						existingRoutingTableEntry5 = models.NewRoutingTableEntry(
+							[]models.BackendServerInfo{
+								models.BackendServerInfo{Address: "some-ip-1", Port: 1234, TLSPort: 60012, InstanceID: "another-meow-for-the-back", ModificationTag: modificationTag, TTL: ttl},
+								models.BackendServerInfo{Address: "some-ip-2", Port: 1234, TLSPort: 60013, InstanceID: "griffin", ModificationTag: modificationTag, TTL: ttl},
+							},
+						)
+						Expect(routingTable.Set(existingRoutingKey5, existingRoutingTableEntry5)).To(BeTrue())
+						mapping := apimodels.NewTcpRouteMapping(
+							routerGroupGuid,
+							externalPort5,
+							"some-ip-2",
+							1234,
+							60013,
+							"griffin",
+							nil,
+							ttl,
+							modificationTag,
+						)
+						tcpEvent = routing_api.TcpEvent{
+							TcpRouteMapping: mapping,
+							Action:          "Delete",
+						}
+					})
+
+					It("deletes backend from entry and calls configurer", func() {
+						err := updater.HandleEvent(tcpEvent)
+						Expect(err).NotTo(HaveOccurred())
+						expectedRoutingTableEntry := models.NewRoutingTableEntry(
+							[]models.BackendServerInfo{
+								models.BackendServerInfo{Address: "some-ip-1", Port: 1234, TLSPort: 60012, InstanceID: "another-meow-for-the-back", ModificationTag: modificationTag, TTL: ttl},
+							},
+						)
+						verifyRoutingTableEntry(existingRoutingKey5, expectedRoutingTableEntry)
+						Expect(fakeConfigurer.ConfigureCallCount()).To(Equal(1))
 					})
 				})
 			})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Currently TCP Router does not support TLS/mTLS. Adding this capability enhances security.


Backward Compatibility
---------------
Breaking Change? **No**