### PR TITLE
add backend_tls enabled flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type OAuthConfig struct {
 }
 
 type BackendTLSConfig struct {
+	Enabled              bool   `yaml:"enabled"`
 	CACertificatePath    string `yaml:"ca_cert_path"`
 	ClientCertAndKeyPath string `yaml:"client_cert_and_key_path"`
 }
@@ -69,70 +70,77 @@ func (c *Config) initConfigFromFile(path string) error {
 		return errors.New("haproxy_pid_file is required")
 	}
 
-	if c.BackendTLS.CACertificatePath != "" {
-		pemData, err := os.ReadFile(c.BackendTLS.CACertificatePath)
-		if err != nil {
-			return err
-		}
-
-		pemData = []byte(strings.TrimSpace(string(pemData)))
-		if len(pemData) > 0 {
-			var block *pem.Block
-			block, _ = pem.Decode(pemData)
-			if block == nil {
-				return fmt.Errorf("Invalid PEM block found in file %q", c.BackendTLS.CACertificatePath)
-			}
-			if len(block.Headers) != 0 {
-				return fmt.Errorf("Unexpected headers in PEM block in file %q: %v", c.BackendTLS.CACertificatePath, block.Headers)
-			}
-			if block.Type != "CERTIFICATE" {
-				return fmt.Errorf("Unexpected PEM block type %q in file %q (wanted CERTIFICATE)", block.Type, c.BackendTLS.CACertificatePath)
-			}
-			_, err = x509.ParseCertificate(block.Bytes)
+	if c.BackendTLS.Enabled {
+		if c.BackendTLS.CACertificatePath != "" {
+			pemData, err := os.ReadFile(c.BackendTLS.CACertificatePath)
 			if err != nil {
-				return fmt.Errorf("failed to parse certificate in %q: %s", c.BackendTLS.CACertificatePath, err)
+				return err
+			}
+
+			pemData = []byte(strings.TrimSpace(string(pemData)))
+			if len(pemData) > 0 {
+				var block *pem.Block
+				block, _ = pem.Decode(pemData)
+				if block == nil {
+					return fmt.Errorf("Invalid PEM block found in file %q", c.BackendTLS.CACertificatePath)
+				}
+				if len(block.Headers) != 0 {
+					return fmt.Errorf("Unexpected headers in PEM block in file %q: %v", c.BackendTLS.CACertificatePath, block.Headers)
+				}
+				if block.Type != "CERTIFICATE" {
+					return fmt.Errorf("Unexpected PEM block type %q in file %q (wanted CERTIFICATE)", block.Type, c.BackendTLS.CACertificatePath)
+				}
+				_, err = x509.ParseCertificate(block.Bytes)
+				if err != nil {
+					return fmt.Errorf("failed to parse certificate in %q: %s", c.BackendTLS.CACertificatePath, err)
+				}
+			}
+		} else {
+			return fmt.Errorf("Backend TLS was enabled but no CA certificates were specified")
+		}
+
+		if c.BackendTLS.ClientCertAndKeyPath != "" {
+			pemData, err := os.ReadFile(c.BackendTLS.ClientCertAndKeyPath)
+			if err != nil {
+				return err
+			}
+
+			pemData = []byte(strings.TrimSpace(string(pemData)))
+			var certBlock *pem.Block
+			certBlock, pemData = pem.Decode(pemData)
+			if certBlock == nil {
+				return fmt.Errorf("Invalid PEM CERTIFICATE found in file %q", c.BackendTLS.ClientCertAndKeyPath)
+			}
+			certPEM := bytes.NewBuffer([]byte{})
+			err = pem.Encode(certPEM, certBlock)
+			if err != nil {
+				return fmt.Errorf("Could not encode cert as PEM data: %s", err)
+			}
+
+			pemData = []byte(strings.TrimSpace(string(pemData)))
+			var keyBlock *pem.Block
+			keyBlock, pemData = pem.Decode(pemData)
+			if keyBlock == nil {
+				return fmt.Errorf("Invalid PEM PRIVATE KEY found in file %q", c.BackendTLS.ClientCertAndKeyPath)
+			}
+			keyPEM := bytes.NewBuffer([]byte{})
+			err = pem.Encode(keyPEM, keyBlock)
+			if err != nil {
+				return fmt.Errorf("Could not encode key as PEM data: %s", err)
+			}
+
+			if len(pemData) > 0 {
+				return fmt.Errorf("Unexpected data at the end of %s", c.BackendTLS.ClientCertAndKeyPath)
+			}
+
+			_, err = tls.X509KeyPair(certPEM.Bytes(), keyPEM.Bytes())
+			if err != nil {
+				return fmt.Errorf("Unable to validate backend TLS client cert + key in file %q: %s", c.BackendTLS.ClientCertAndKeyPath, err)
 			}
 		}
-	}
-
-	if c.BackendTLS.ClientCertAndKeyPath != "" {
-		pemData, err := os.ReadFile(c.BackendTLS.ClientCertAndKeyPath)
-		if err != nil {
-			return err
-		}
-
-		pemData = []byte(strings.TrimSpace(string(pemData)))
-		var certBlock *pem.Block
-		certBlock, pemData = pem.Decode(pemData)
-		if certBlock == nil {
-			return fmt.Errorf("Invalid PEM CERTIFICATE found in file %q", c.BackendTLS.ClientCertAndKeyPath)
-		}
-		certPEM := bytes.NewBuffer([]byte{})
-		err = pem.Encode(certPEM, certBlock)
-		if err != nil {
-			return fmt.Errorf("Could not encode cert as PEM data: %s", err)
-		}
-
-		pemData = []byte(strings.TrimSpace(string(pemData)))
-		var keyBlock *pem.Block
-		keyBlock, pemData = pem.Decode(pemData)
-		if keyBlock == nil {
-			return fmt.Errorf("Invalid PEM PRIVATE KEY found in file %q", c.BackendTLS.ClientCertAndKeyPath)
-		}
-		keyPEM := bytes.NewBuffer([]byte{})
-		err = pem.Encode(keyPEM, keyBlock)
-		if err != nil {
-			return fmt.Errorf("Could not encode key as PEM data: %s", err)
-		}
-
-		if len(pemData) > 0 {
-			return fmt.Errorf("Unexpected data at the end of %s", c.BackendTLS.ClientCertAndKeyPath)
-		}
-
-		_, err = tls.X509KeyPair(certPEM.Bytes(), keyPEM.Bytes())
-		if err != nil {
-			return fmt.Errorf("Unable to validate backend TLS client cert + key in file %q: %s", c.BackendTLS.ClientCertAndKeyPath, err)
-		}
+	} else {
+		c.BackendTLS.CACertificatePath = ""
+		c.BackendTLS.ClientCertAndKeyPath = ""
 	}
 
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Config", func() {
 				IsolationSegments:            []string{"foo-iso-seg"},
 				ReservedSystemComponentPorts: []int{8080, 8081},
 				BackendTLS: config.BackendTLSConfig{
+					Enabled:              true,
 					CACertificatePath:    caFile,
 					ClientCertAndKeyPath: certAndKeyFile,
 				},
@@ -104,28 +105,47 @@ var _ = Describe("Config", func() {
 		})
 	})
 
-	Context("when the CA path is not a valid CA", func() {
-		It("returns an error", func() {
-			_, err := config.New("fixtures/bad_ca_config.yml")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Invalid PEM block found in file"))
+	Context("When backend_tls is enabled", func() {
+		Context("when the CA path is not a valid CA", func() {
+			It("returns an error", func() {
+				_, err := config.New("fixtures/bad_ca_config.yml")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Invalid PEM block found in file"))
+			})
+		})
+
+		Context("when the Client Cert/key pair are not valid", func() {
+			It("returns an error", func() {
+				_, err := config.New("fixtures/bad_client_cert_config.yml")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Invalid PEM CERTIFICATE found in file"))
+			})
+		})
+
+		Context("when the Client Cert/key pair are mismatched", func() {
+			It("returns an error", func() {
+				_, err := config.New("fixtures/mismatched_client_cert_config.yml")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Unable to validate backend TLS client cert + key in file"))
+				Expect(err.Error()).To(ContainSubstring("tls: private key does not match public key"))
+			})
+		})
+		Context("when CA path is not specified", func() {
+			It("returns an error", func() {
+				_, err := config.New("fixtures/no_ca.yml")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Backend TLS was enabled but no CA certificates were specified"))
+			})
 		})
 	})
 
-	Context("when the Client Cert/key pair are not valid", func() {
-		It("returns an error", func() {
-			_, err := config.New("fixtures/bad_client_cert_config.yml")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Invalid PEM CERTIFICATE found in file"))
-		})
-	})
-
-	Context("when the Client Cert/key pair are mismatched", func() {
-		It("returns an error", func() {
-			_, err := config.New("fixtures/mismatched_client_cert_config.yml")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Unable to validate backend TLS client cert + key in file"))
-			Expect(err.Error()).To(ContainSubstring("tls: private key does not match public key"))
+	Context("when backend_tls is disabled", func() {
+		It("does not set any of the backend_tls cert/ca values", func() {
+			cfg, err := config.New("fixtures/disabled_tls.yml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.BackendTLS).To(Equal(config.BackendTLSConfig{
+				Enabled: false,
+			}))
 		})
 	})
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Config", func() {
+var _ = Describe("Config", Serial, func() {
 	caFile := "fixtures/ca.pem"
 	certAndKeyFile := "fixtures/cert_and_key.pem"
 	mismatchedCertAndKeyFile := "fixtures/mismatched_cert_and_key.pem"
@@ -18,18 +18,24 @@ var _ = Describe("Config", func() {
 	BeforeEach(func() {
 		// Generate a CA and move it into the correct location for the fixture
 		tmpCAFile, _ := tlshelpers.GenerateCa()
-		err := os.Rename(tmpCAFile, caFile)
+		caBytes, err := os.ReadFile(tmpCAFile)
+		Expect(err).ToNot(HaveOccurred())
+		f, err := os.OpenFile(caFile, os.O_RDWR|os.O_CREATE, 0644)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = f.Write(caBytes)
+		Expect(err).ToNot(HaveOccurred())
+		err = os.Remove(tmpCAFile)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Generate a second trusted CA and add it to the fixture's CA file
 		tmpCAFile2, _ := tlshelpers.GenerateCa()
-		caBytes, err := os.ReadFile(tmpCAFile2)
-		Expect(err).ToNot(HaveOccurred())
-		f, err := os.OpenFile(caFile, os.O_RDWR|os.O_APPEND, 0644)
+		caBytes, err = os.ReadFile(tmpCAFile2)
 		Expect(err).ToNot(HaveOccurred())
 		_, err = f.Write(caBytes)
 		Expect(err).ToNot(HaveOccurred())
 		err = os.Remove(tmpCAFile2)
+		Expect(err).ToNot(HaveOccurred())
+		err = f.Close()
 		Expect(err).ToNot(HaveOccurred())
 
 		// Generate a client cert + key, and move it into the correct location for the fixture

--- a/config/fixtures/bad_ca_config.yml
+++ b/config/fixtures/bad_ca_config.yml
@@ -18,4 +18,5 @@ haproxy_pid_file: /path/to/pid/file
 isolation_segments: ["foo-iso-seg"]
 reserved_system_component_ports: [8080, 8081]
 backend_tls:
+  enabled: true
   ca_cert_path: fixtures/bad_ca.pem

--- a/config/fixtures/bad_client_cert_config.yml
+++ b/config/fixtures/bad_client_cert_config.yml
@@ -18,5 +18,6 @@ haproxy_pid_file: /path/to/pid/file
 isolation_segments: ["foo-iso-seg"]
 reserved_system_component_ports: [8080, 8081]
 backend_tls:
+  enabled: true
   ca_cert_path: fixtures/ca.pem
   client_cert_and_key_path: fixtures/bad_cert_and_key.pem

--- a/config/fixtures/disabled_tls.yml
+++ b/config/fixtures/disabled_tls.yml
@@ -18,6 +18,6 @@ haproxy_pid_file: /path/to/pid/file
 isolation_segments: ["foo-iso-seg"]
 reserved_system_component_ports: [8080, 8081]
 backend_tls:
-  enabled: true
+  enabled: false
   ca_cert_path: fixtures/ca.pem
-  client_cert_and_key_path: fixtures/mismatched_cert_and_key.pem
+  client_cert_and_key_path: fixtures/cert_and_key.pem

--- a/config/fixtures/no_ca.yml
+++ b/config/fixtures/no_ca.yml
@@ -19,5 +19,3 @@ isolation_segments: ["foo-iso-seg"]
 reserved_system_component_ports: [8080, 8081]
 backend_tls:
   enabled: true
-  ca_cert_path: fixtures/ca.pem
-  client_cert_and_key_path: fixtures/mismatched_cert_and_key.pem

--- a/config/fixtures/valid_config.yml
+++ b/config/fixtures/valid_config.yml
@@ -18,5 +18,6 @@ haproxy_pid_file: /path/to/pid/file
 isolation_segments: ["foo-iso-seg"]
 reserved_system_component_ports: [8080, 8081]
 backend_tls:
+  enabled: true
   ca_cert_path: fixtures/ca.pem
   client_cert_and_key_path: fixtures/cert_and_key.pem

--- a/configurer/haproxy/config_marshaller.go
+++ b/configurer/haproxy/config_marshaller.go
@@ -82,8 +82,8 @@ func (cm configMarshaller) marshalHAProxyBackend(backendName string, backend mod
 	output.WriteString("\n  mode tcp")
 
 	for _, server := range backend {
-		if server.TLSPort > 0 && backendTlsCfg.CACertificatePath == "" {
-			cm.logger.Error("route-missing-tls-information", fmt.Errorf("Backend TLS Port was set, but CA file path has not been configured"), lager.Data{"backend": backend})
+		if server.TLSPort > 0 && !backendTlsCfg.Enabled {
+			cm.logger.Error("backend-tls-not-enabled", fmt.Errorf("Backend TLS Port was set, but backend_tls has not been enabled for tcp-router"), lager.Data{"backend": backend})
 			//skip this endpoint, but there may be other backends with tlsport <= 0 that we should still set
 			continue
 		}
@@ -95,7 +95,7 @@ func (cm configMarshaller) marshalHAProxyBackend(backendName string, backend mod
 				output.WriteString(fmt.Sprintf(" crt %s", backendTlsCfg.ClientCertAndKeyPath))
 			}
 		} else {
-			if server.TLSPort == 0 && backendTlsCfg.CACertificatePath != "" {
+			if server.TLSPort == 0 && backendTlsCfg.Enabled {
 				cm.logger.Error("route-missing-tls-information", fmt.Errorf("Backend TLSPort was set to 0. If TLS is intentionally off for this backend, set this to -1 to suppress this message"), lager.Data{"backend": server})
 			}
 			output.WriteString(fmt.Sprintf("\n  server server_%s_%d %s:%d", server.Address, server.Port, server.Address, server.Port))

--- a/configurer/haproxy/config_marshaller_test.go
+++ b/configurer/haproxy/config_marshaller_test.go
@@ -25,6 +25,7 @@ var _ = Describe("ConfigMarshaller", func() {
 			haproxyConf = models.HAProxyConfig{}
 			marshaller = haproxy.NewConfigMarshaller(logger)
 			backendTlsCfg = config.BackendTLSConfig{
+				Enabled:           false,
 				CACertificatePath: "/fake/path/to/ca.pem",
 			}
 		})
@@ -207,32 +208,12 @@ backend backend_80
 			})
 		})
 
-		Context("when a TLSPort and CA cert filepath are provided", func() {
-			It("configures the backend server to use the TLSPort", func() {
-				haproxyConf = models.HAProxyConfig{
-					80: {
-						"": {
-							{Address: "host-88.internal", Port: 8888, TLSPort: 8443, InstanceID: "host-88-instance-id"},
-						},
-					},
-				}
-				Expect(marshaller.Marshal(haproxyConf, backendTlsCfg)).To(Equal(`
-frontend frontend_80
-  mode tcp
-  bind :80
-  default_backend backend_80
-
-backend backend_80
-  mode tcp
-  server server_host-88.internal_8443 host-88.internal:8443 ssl verify required verifyhost host-88-instance-id ca-file /fake/path/to/ca.pem
-`))
+		Context("when backend_tls is enabled", func() {
+			BeforeEach(func() {
+				backendTlsCfg.Enabled = true
 			})
-
-			Context("when a client cert is provided", func() {
-				BeforeEach(func() {
-					backendTlsCfg.ClientCertAndKeyPath = "/fake/path/to/client_cert_and_key.pem"
-				})
-				It("configures the backend server to use the TLSPort with mTLS", func() {
+			Context("when TLS port is specified", func() {
+				It("configures the backend server to use the TLSPort", func() {
 					haproxyConf = models.HAProxyConfig{
 						80: {
 							"": {
@@ -248,23 +229,114 @@ frontend frontend_80
 
 backend backend_80
   mode tcp
+  server server_host-88.internal_8443 host-88.internal:8443 ssl verify required verifyhost host-88-instance-id ca-file /fake/path/to/ca.pem
+`))
+				})
+
+				Context("when a client cert is provided", func() {
+					BeforeEach(func() {
+						backendTlsCfg.ClientCertAndKeyPath = "/fake/path/to/client_cert_and_key.pem"
+					})
+					It("configures the backend server to use the TLSPort with mTLS", func() {
+						haproxyConf = models.HAProxyConfig{
+							80: {
+								"": {
+									{Address: "host-88.internal", Port: 8888, TLSPort: 8443, InstanceID: "host-88-instance-id"},
+								},
+							},
+						}
+						Expect(marshaller.Marshal(haproxyConf, backendTlsCfg)).To(Equal(`
+frontend frontend_80
+  mode tcp
+  bind :80
+  default_backend backend_80
+
+backend backend_80
+  mode tcp
   server server_host-88.internal_8443 host-88.internal:8443 ssl verify required verifyhost host-88-instance-id ca-file /fake/path/to/ca.pem crt /fake/path/to/client_cert_and_key.pem
+`))
+
+					})
+				})
+			})
+			Context("when TLSPort is 0", func() {
+				It("Logs an error indicating that the backend is not being encrypted", func() {
+					haproxyConf = models.HAProxyConfig{
+						80: {
+							"": {
+								{Address: "host-88.internal", Port: 8888, TLSPort: 0, InstanceID: "host-88-instance-id"},
+							},
+						},
+					}
+					marshaller.Marshal(haproxyConf, backendTlsCfg)
+					Expect(logger).To(gbytes.Say("route-missing-tls-information"))
+				})
+				It("uses the non-tls backend port", func() {
+					haproxyConf = models.HAProxyConfig{
+						80: {
+							"": {
+								{Address: "host-88.internal", Port: 8888, TLSPort: 0, InstanceID: "host-88-instance-id"},
+							},
+						},
+					}
+					Expect(marshaller.Marshal(haproxyConf, backendTlsCfg)).To(Equal(`
+frontend frontend_80
+  mode tcp
+  bind :80
+  default_backend backend_80
+
+backend backend_80
+  mode tcp
+  server server_host-88.internal_8888 host-88.internal:8888
+`))
+				})
+			})
+			Context("when TLSPort is -1", func() {
+				It("does not log an error", func() {
+					haproxyConf = models.HAProxyConfig{
+						80: {
+							"": {
+								{Address: "host-88.internal", Port: 8888, TLSPort: -1, InstanceID: "host-88-instance-id"},
+							},
+						},
+					}
+					marshaller.Marshal(haproxyConf, backendTlsCfg)
+					Expect(logger).NotTo(gbytes.Say("route-missing-tls-information"))
+				})
+				It("uses the non-tls backend port", func() {
+					haproxyConf = models.HAProxyConfig{
+						80: {
+							"": {
+								{Address: "host-88.internal", Port: 8888, TLSPort: -1, InstanceID: "host-88-instance-id"},
+							},
+						},
+					}
+					Expect(marshaller.Marshal(haproxyConf, backendTlsCfg)).To(Equal(`
+frontend frontend_80
+  mode tcp
+  bind :80
+  default_backend backend_80
+
+backend backend_80
+  mode tcp
+  server server_host-88.internal_8888 host-88.internal:8888
 `))
 
 				})
 			})
 		})
 
-		Context("when a TLSPort is provided but no CA cert filepath is provided", func() {
-			It("configures the backend server to use the TLSPort", func() {
-				haproxyConf = models.HAProxyConfig{
-					80: {
-						"": {
-							{Address: "host-88.internal", Port: 8888, TLSPort: 8443, InstanceID: "host-88-instance-id"},
+		Context("when backend_tls is disabled", func() {
+			Context("when a TLSPort is provided", func() {
+				It("loggs an error", func() {
+					haproxyConf = models.HAProxyConfig{
+						80: {
+							"": {
+								{Address: "host-88.internal", Port: 8888, TLSPort: 8443, InstanceID: "host-88-instance-id"},
+							},
 						},
-					},
-				}
-				Expect(marshaller.Marshal(haproxyConf, config.BackendTLSConfig{})).To(Equal(`
+					}
+					Expect(marshaller.Marshal(haproxyConf, config.BackendTLSConfig{Enabled: false})).To(Equal(`
 frontend frontend_80
   mode tcp
   bind :80
@@ -273,73 +345,8 @@ frontend frontend_80
 backend backend_80
   mode tcp
 `))
-				Expect(logger).To(gbytes.Say("Backend TLS Port was set, but CA file path has not been configured"))
-			})
-		})
-
-		Context("when TLSPort is 0", func() {
-			It("Logs an error indicating that the backend is not being encrypted", func() {
-				haproxyConf = models.HAProxyConfig{
-					80: {
-						"": {
-							{Address: "host-88.internal", Port: 8888, TLSPort: 0, InstanceID: "host-88-instance-id"},
-						},
-					},
-				}
-				marshaller.Marshal(haproxyConf, backendTlsCfg)
-				Expect(logger).To(gbytes.Say("route-missing-tls-information"))
-			})
-			It("uses the non-tls backend port", func() {
-				haproxyConf = models.HAProxyConfig{
-					80: {
-						"": {
-							{Address: "host-88.internal", Port: 8888, TLSPort: -1, InstanceID: "host-88-instance-id"},
-						},
-					},
-				}
-				Expect(marshaller.Marshal(haproxyConf, backendTlsCfg)).To(Equal(`
-frontend frontend_80
-  mode tcp
-  bind :80
-  default_backend backend_80
-
-backend backend_80
-  mode tcp
-  server server_host-88.internal_8888 host-88.internal:8888
-`))
-			})
-		})
-		Context("when TLSPort is -1", func() {
-			It("does not log an error", func() {
-				haproxyConf = models.HAProxyConfig{
-					80: {
-						"": {
-							{Address: "host-88.internal", Port: 8888, TLSPort: -1, InstanceID: "host-88-instance-id"},
-						},
-					},
-				}
-				marshaller.Marshal(haproxyConf, backendTlsCfg)
-				Expect(logger).NotTo(gbytes.Say("route-missing-tls-information"))
-			})
-			It("uses the non-tls backend port", func() {
-				haproxyConf = models.HAProxyConfig{
-					80: {
-						"": {
-							{Address: "host-88.internal", Port: 8888, TLSPort: -1, InstanceID: "host-88-instance-id"},
-						},
-					},
-				}
-				Expect(marshaller.Marshal(haproxyConf, backendTlsCfg)).To(Equal(`
-frontend frontend_80
-  mode tcp
-  bind :80
-  default_backend backend_80
-
-backend backend_80
-  mode tcp
-  server server_host-88.internal_8888 host-88.internal:8888
-`))
-
+					Expect(logger).To(gbytes.Say("Backend TLS Port was set, but backend_tls has not been enabled for tcp-router"))
+				})
 			})
 		})
 	})

--- a/models/routing_table_test.go
+++ b/models/routing_table_test.go
@@ -271,7 +271,7 @@ var _ = Describe("RoutingTable", func() {
 
 			It("returns a RoutingTableEntry with a TLSPort and InstanceID", func() {
 				Expect(existingRoutingTableEntry.Backends).To(HaveLen(1))
-				for k, _ := range existingRoutingTableEntry.Backends {
+				for k := range existingRoutingTableEntry.Backends {
 					Expect(k.TLSPort).To(Equal((8443)))
 					Expect(k.InstanceID).To(Equal("meow"))
 				}


### PR DESCRIPTION
Summary
---------------

This adds a backend_tls.enabled flag to make Amelia happy. I don't like features, that require multiple properties (like certs in this case), to be enabled based on the presence of one of those properties. I find it cleaner to have a clear on/off switch.


Backward Compatibility
---------------
Breaking Change? No

