### PR TITLE
Allow backend port to be 0 when backend tls port is provided on a tcp…

### DIFF
--- a/models/haproxy_config.go
+++ b/models/haproxy_config.go
@@ -33,7 +33,7 @@ func NewHAProxyConfig(routingTable RoutingTable, logger lager.Logger) HAProxyCon
 		backends := make(HAProxyBackend, 0)
 
 		for backendKey := range entry.Backends {
-			if backendKey.Port == 0 {
+			if backendKey.Port == 0 && backendKey.TLSPort <= 0 {
 				logError(logger, "backend_configuration.port", routingKey, backendKey.Port)
 				continue
 			}

--- a/models/haproxy_config_test.go
+++ b/models/haproxy_config_test.go
@@ -147,6 +147,24 @@ var _ = Describe("HAProxyConfig", func() {
 					},
 				}))
 			})
+			Context("and backend port 0", func() {
+				It("creates a valid HAProxyConfig", func() {
+					instanceId := "foo"
+					routingTable.Entries[RoutingKey{Port: 80}] = RoutingTableEntry{
+						Backends: map[BackendServerKey]BackendServerDetails{
+							BackendServerKey{Address: "valid-host-1.example.com", Port: 0, TLSPort: 1443, InstanceID: instanceId}: {},
+						},
+					}
+					Expect(NewHAProxyConfig(routingTable, logger)).To(Equal(HAProxyConfig{
+						80: {
+							"": {
+								{Address: "valid-host-1.example.com", Port: 0, TLSPort: 1443, InstanceID: instanceId},
+							},
+						},
+					}))
+
+				})
+			})
 		})
 
 		Context("when multiple valid frontends exist", func() {


### PR DESCRIPTION
… route

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
