### PR TITLE
Add support for gracefully removing tcp-router from loadbalancers before shutting down.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -44,8 +45,11 @@ type Config struct {
 	HaProxyPidFile               string           `yaml:"haproxy_pid_file"`
 	IsolationSegments            []string         `yaml:"isolation_segments"`
 	ReservedSystemComponentPorts []int            `yaml:"reserved_system_component_ports"`
+	DrainWaitDuration            time.Duration    `yaml:"drain_wait"`
 	BackendTLS                   BackendTLSConfig `yaml:"backend_tls"`
 }
+
+const DrainWaitDefault = 20 * time.Second
 
 func New(path string) (*Config, error) {
 	c := &Config{}
@@ -68,6 +72,10 @@ func (c *Config) initConfigFromFile(path string) error {
 
 	if c.HaProxyPidFile == "" {
 		return errors.New("haproxy_pid_file is required")
+	}
+
+	if c.DrainWaitDuration < 0 {
+		c.DrainWaitDuration = DrainWaitDefault
 	}
 
 	if c.BackendTLS.Enabled {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"fmt"
 	"os"
+	"time"
 
 	tlshelpers "code.cloudfoundry.org/cf-routing-test-helpers/tls"
 	"code.cloudfoundry.org/cf-tcp-router/config"
@@ -64,6 +65,7 @@ var _ = Describe("Config", Serial, func() {
 	Context("when a valid config", func() {
 		It("loads the config", func() {
 			expectedCfg := config.Config{
+				DrainWaitDuration: 40 * time.Second,
 				OAuth: config.OAuthConfig{
 					TokenEndpoint:     "uaa.service.cf.internal",
 					ClientName:        "someclient",
@@ -196,6 +198,14 @@ var _ = Describe("Config", Serial, func() {
 			cfg, err := config.New("fixtures/missing_oauth_fields.yml")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*cfg).To(Equal(expectedCfg))
+		})
+	})
+	Context("when drain_wait is a negative number", func() {
+		It("defaults to 20s", func() {
+			cfg, err := config.New("fixtures/negative_drain_wait.yml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.DrainWaitDuration).To(Equal(20 * time.Second))
+
 		})
 	})
 })

--- a/config/fixtures/missing_drain_wait.yml
+++ b/config/fixtures/missing_drain_wait.yml
@@ -21,5 +21,3 @@ backend_tls:
   enabled: true
   ca_cert_path: fixtures/ca.pem
   client_cert_and_key_path: fixtures/cert_and_key.pem
-
-drain_wait: 40s

--- a/config/fixtures/negative_drain_wait.yml
+++ b/config/fixtures/negative_drain_wait.yml
@@ -22,4 +22,4 @@ backend_tls:
   ca_cert_path: fixtures/ca.pem
   client_cert_and_key_path: fixtures/cert_and_key.pem
 
-drain_wait: 40s
+drain_wait: -40s

--- a/config/fixtures/zero_drain_wait.yml
+++ b/config/fixtures/zero_drain_wait.yml
@@ -22,4 +22,4 @@ backend_tls:
   ca_cert_path: fixtures/ca.pem
   client_cert_and_key_path: fixtures/cert_and_key.pem
 
-drain_wait: 40s
+drain_wait: 0s

--- a/configurer/configurer.go
+++ b/configurer/configurer.go
@@ -16,7 +16,7 @@ const (
 
 //go:generate counterfeiter -o fakes/fake_configurer.go . RouterConfigurer
 type RouterConfigurer interface {
-	Configure(routingTable models.RoutingTable) error
+	Configure(routingTable models.RoutingTable, forceHealthCheckToFail bool) error
 }
 
 func NewConfigurer(logger lager.Logger, tcpLoadBalancer string, tcpLoadBalancerBaseCfg string, tcpLoadBalancerCfg string, monitor monitor.Monitor, scriptRunner haproxy.ScriptRunner, backendTlsCfg config.BackendTLSConfig) RouterConfigurer {

--- a/configurer/fakes/fake_configurer.go
+++ b/configurer/fakes/fake_configurer.go
@@ -9,10 +9,11 @@ import (
 )
 
 type FakeRouterConfigurer struct {
-	ConfigureStub        func(models.RoutingTable) error
+	ConfigureStub        func(models.RoutingTable, bool) error
 	configureMutex       sync.RWMutex
 	configureArgsForCall []struct {
 		arg1 models.RoutingTable
+		arg2 bool
 	}
 	configureReturns struct {
 		result1 error
@@ -24,18 +25,19 @@ type FakeRouterConfigurer struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeRouterConfigurer) Configure(arg1 models.RoutingTable) error {
+func (fake *FakeRouterConfigurer) Configure(arg1 models.RoutingTable, arg2 bool) error {
 	fake.configureMutex.Lock()
 	ret, specificReturn := fake.configureReturnsOnCall[len(fake.configureArgsForCall)]
 	fake.configureArgsForCall = append(fake.configureArgsForCall, struct {
 		arg1 models.RoutingTable
-	}{arg1})
+		arg2 bool
+	}{arg1, arg2})
 	stub := fake.ConfigureStub
 	fakeReturns := fake.configureReturns
-	fake.recordInvocation("Configure", []interface{}{arg1})
+	fake.recordInvocation("Configure", []interface{}{arg1, arg2})
 	fake.configureMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -49,17 +51,17 @@ func (fake *FakeRouterConfigurer) ConfigureCallCount() int {
 	return len(fake.configureArgsForCall)
 }
 
-func (fake *FakeRouterConfigurer) ConfigureCalls(stub func(models.RoutingTable) error) {
+func (fake *FakeRouterConfigurer) ConfigureCalls(stub func(models.RoutingTable, bool) error) {
 	fake.configureMutex.Lock()
 	defer fake.configureMutex.Unlock()
 	fake.ConfigureStub = stub
 }
 
-func (fake *FakeRouterConfigurer) ConfigureArgsForCall(i int) models.RoutingTable {
+func (fake *FakeRouterConfigurer) ConfigureArgsForCall(i int) (models.RoutingTable, bool) {
 	fake.configureMutex.RLock()
 	defer fake.configureMutex.RUnlock()
 	argsForCall := fake.configureArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeRouterConfigurer) ConfigureReturns(result1 error) {

--- a/configurer/haproxy/fakes/fake_script_runner.go
+++ b/configurer/haproxy/fakes/fake_script_runner.go
@@ -8,9 +8,10 @@ import (
 )
 
 type FakeScriptRunner struct {
-	RunStub        func() error
+	RunStub        func(bool) error
 	runMutex       sync.RWMutex
 	runArgsForCall []struct {
+		arg1 bool
 	}
 	runReturns struct {
 		result1 error
@@ -22,17 +23,18 @@ type FakeScriptRunner struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeScriptRunner) Run() error {
+func (fake *FakeScriptRunner) Run(arg1 bool) error {
 	fake.runMutex.Lock()
 	ret, specificReturn := fake.runReturnsOnCall[len(fake.runArgsForCall)]
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
-	}{})
+		arg1 bool
+	}{arg1})
 	stub := fake.RunStub
 	fakeReturns := fake.runReturns
-	fake.recordInvocation("Run", []interface{}{})
+	fake.recordInvocation("Run", []interface{}{arg1})
 	fake.runMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -46,10 +48,17 @@ func (fake *FakeScriptRunner) RunCallCount() int {
 	return len(fake.runArgsForCall)
 }
 
-func (fake *FakeScriptRunner) RunCalls(stub func() error) {
+func (fake *FakeScriptRunner) RunCalls(stub func(bool) error) {
 	fake.runMutex.Lock()
 	defer fake.runMutex.Unlock()
 	fake.RunStub = stub
+}
+
+func (fake *FakeScriptRunner) RunArgsForCall(i int) bool {
+	fake.runMutex.RLock()
+	defer fake.runMutex.RUnlock()
+	argsForCall := fake.runArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeScriptRunner) RunReturns(result1 error) {

--- a/configurer/haproxy/fixtures/testscript
+++ b/configurer/haproxy/fixtures/testscript
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 echo "hello test"
+
+echo "IS_DRAINING=${IS_DRAINING}"

--- a/configurer/haproxy/haproxy_configurer.go
+++ b/configurer/haproxy/haproxy_configurer.go
@@ -56,7 +56,7 @@ func NewHaProxyConfigurer(logger lager.Logger, configMarshaller ConfigMarshaller
 	}, nil
 }
 
-func (h *Configurer) Configure(routingTable models.RoutingTable) error {
+func (h *Configurer) Configure(routingTable models.RoutingTable, forceHealthCheckToFail bool) error {
 	h.monitor.StopWatching()
 	h.configFileLock.Lock()
 	defer h.configFileLock.Unlock()
@@ -97,7 +97,7 @@ func (h *Configurer) Configure(routingTable models.RoutingTable) error {
 	if h.scriptRunner != nil {
 		h.logger.Info("reloading-haproxy")
 
-		err = h.scriptRunner.Run()
+		err = h.scriptRunner.Run(forceHealthCheckToFail)
 		if err != nil {
 			h.logger.Error("failed-to-reload-haproxy", err)
 			return err

--- a/configurer/haproxy/haproxy_configurer_test.go
+++ b/configurer/haproxy/haproxy_configurer_test.go
@@ -132,7 +132,7 @@ var _ = Describe("HaproxyConfigurer", func() {
 
 			Context("when Configure is called once", func() {
 				It("writes contents to file", func() {
-					err = haproxyConfigurer.Configure(routingTable)
+					err = haproxyConfigurer.Configure(routingTable, false)
 					Expect(err).ToNot(HaveOccurred())
 
 					currentConfigTemplateContent, err = os.ReadFile(generatedHaproxyCfgFile)
@@ -149,10 +149,10 @@ var _ = Describe("HaproxyConfigurer", func() {
 
 			Context("when Configure is called twice", func() {
 				It("overwrites the file every time (does not accumulate marshalled contents)", func() {
-					err = haproxyConfigurer.Configure(routingTable)
+					err = haproxyConfigurer.Configure(routingTable, false)
 					Expect(err).ToNot(HaveOccurred())
 
-					err = haproxyConfigurer.Configure(routingTable)
+					err = haproxyConfigurer.Configure(routingTable, false)
 					Expect(err).ToNot(HaveOccurred())
 
 					currentConfigTemplateContent, err = os.ReadFile(generatedHaproxyCfgFile)
@@ -166,6 +166,25 @@ var _ = Describe("HaproxyConfigurer", func() {
 					Expect(fakeMonitor.StopWatchingCallCount()).To(Equal(2))
 					Expect(fakeScriptRunner.RunCallCount()).To(Equal(2))
 					Expect(fakeMonitor.StartWatchingCallCount()).To(Equal(2))
+				})
+			})
+
+			Context("when Configure is called with forceHealthCheckToFail set to true", func() {
+				It("calls scriptRunner.Run() with true", func() {
+					err = haproxyConfigurer.Configure(routingTable, true)
+					Expect(err).ToNot(HaveOccurred())
+					forceHealthCheckToFail := fakeScriptRunner.RunArgsForCall(0)
+					Expect(forceHealthCheckToFail).To(BeTrue())
+
+				})
+			})
+			Context("when Configure is called with forceHealthCheckToFail set to false", func() {
+				It("calls scriptRunner.Run() with false", func() {
+					err = haproxyConfigurer.Configure(routingTable, false)
+					Expect(err).ToNot(HaveOccurred())
+					forceHealthCheckToFail := fakeScriptRunner.RunArgsForCall(0)
+					Expect(forceHealthCheckToFail).To(BeFalse())
+
 				})
 			})
 		})

--- a/configurer/haproxy/script_runner.go
+++ b/configurer/haproxy/script_runner.go
@@ -8,7 +8,7 @@ import (
 
 //go:generate counterfeiter -o fakes/fake_script_runner.go . ScriptRunner
 type ScriptRunner interface {
-	Run() error
+	Run(forceHealthCheckToFail bool) error
 }
 
 type CommandRunner struct {
@@ -17,11 +17,21 @@ type CommandRunner struct {
 }
 
 func CreateCommandRunner(scriptPath string, logger lager.Logger) *CommandRunner {
-	return &CommandRunner{scriptPath, logger}
+	return &CommandRunner{
+		scriptPath: scriptPath,
+		logger:     logger,
+	}
 }
 
-func (cmd *CommandRunner) Run() error {
-	output, err := exec.Command(cmd.scriptPath).CombinedOutput()
+func (cmd *CommandRunner) Run(forceHealthCheckToFail bool) error {
+	runnerCmd := exec.Command(cmd.scriptPath)
+
+	if forceHealthCheckToFail {
+		cmd.logger.Debug("setting-drain-mode")
+		runnerCmd.Env = append(runnerCmd.Env, "IS_DRAINING=true")
+	}
+
+	output, err := runnerCmd.CombinedOutput()
 	cmd.logger.Info("running-script", lager.Data{"command": string(cmd.scriptPath), "output": string(output), "error": err})
 	return err
 }

--- a/main_suite_test.go
+++ b/main_suite_test.go
@@ -266,6 +266,7 @@ func generateTCPRouterConfigFile(oauthServerPort int, uaaCACertsPath string, rou
 			ClientSecret:      "somesecret",
 			Port:              oauthServerPort,
 		},
+		DrainWaitDuration: 3 * time.Second,
 		RoutingAPI: config.RoutingAPIConfig{
 			AuthDisabled: routingApiAuthDisabled,
 		},

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -52,9 +52,11 @@ func (m *monitor) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 
 	for {
 		select {
-		case <-signals:
-			m.logger.Info("stopping")
-			return nil
+		case sig := <-signals:
+			if sig != syscall.SIGUSR2 {
+				m.logger.Info("stopping")
+				return nil
+			}
 		case <-time.After(time.Second):
 			if atomic.LoadInt32(&m.stopWatching) == 0 {
 				err = watchPID(m.haproxyPIDFile, m.logger)

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"code.cloudfoundry.org/cf-tcp-router/monitor"
 	"code.cloudfoundry.org/lager/v3"
@@ -134,4 +135,11 @@ var _ = Describe("Monitor", func() {
 		})
 	})
 
+	Context("when signaled with SIGUSR2", func() {
+		It("does not shut down", func() {
+			process.Signal(syscall.SIGUSR2)
+
+			Consistently(process.Wait()).ShouldNot(Receive())
+		})
+	})
 })

--- a/routing_table/fakes/fake_updater.go
+++ b/routing_table/fakes/fake_updater.go
@@ -9,6 +9,16 @@ import (
 )
 
 type FakeUpdater struct {
+	DrainStub        func() error
+	drainMutex       sync.RWMutex
+	drainArgsForCall []struct {
+	}
+	drainReturns struct {
+		result1 error
+	}
+	drainReturnsOnCall map[int]struct {
+		result1 error
+	}
 	HandleEventStub        func(routing_api.TcpEvent) error
 	handleEventMutex       sync.RWMutex
 	handleEventArgsForCall []struct {
@@ -40,6 +50,59 @@ type FakeUpdater struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeUpdater) Drain() error {
+	fake.drainMutex.Lock()
+	ret, specificReturn := fake.drainReturnsOnCall[len(fake.drainArgsForCall)]
+	fake.drainArgsForCall = append(fake.drainArgsForCall, struct {
+	}{})
+	stub := fake.DrainStub
+	fakeReturns := fake.drainReturns
+	fake.recordInvocation("Drain", []interface{}{})
+	fake.drainMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeUpdater) DrainCallCount() int {
+	fake.drainMutex.RLock()
+	defer fake.drainMutex.RUnlock()
+	return len(fake.drainArgsForCall)
+}
+
+func (fake *FakeUpdater) DrainCalls(stub func() error) {
+	fake.drainMutex.Lock()
+	defer fake.drainMutex.Unlock()
+	fake.DrainStub = stub
+}
+
+func (fake *FakeUpdater) DrainReturns(result1 error) {
+	fake.drainMutex.Lock()
+	defer fake.drainMutex.Unlock()
+	fake.DrainStub = nil
+	fake.drainReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeUpdater) DrainReturnsOnCall(i int, result1 error) {
+	fake.drainMutex.Lock()
+	defer fake.drainMutex.Unlock()
+	fake.DrainStub = nil
+	if fake.drainReturnsOnCall == nil {
+		fake.drainReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.drainReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeUpdater) HandleEvent(arg1 routing_api.TcpEvent) error {
@@ -207,6 +270,8 @@ func (fake *FakeUpdater) SyncingReturnsOnCall(i int, result1 bool) {
 func (fake *FakeUpdater) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.drainMutex.RLock()
+	defer fake.drainMutex.RUnlock()
 	fake.handleEventMutex.RLock()
 	defer fake.handleEventMutex.RUnlock()
 	fake.pruneStaleRoutesMutex.RLock()

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"os"
+	"syscall"
 	"time"
 
 	"code.cloudfoundry.org/clock"
@@ -43,10 +44,12 @@ func (s *Syncer) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 		select {
 		case <-syncTicker.C():
 			s.sync()
-		case <-signals:
-			s.logger.Info("stopping")
-			syncTicker.Stop()
-			return nil
+		case sig := <-signals:
+			if sig != syscall.SIGUSR2 {
+				s.logger.Info("stopping")
+				syncTicker.Stop()
+				return nil
+			}
 		}
 	}
 }

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -2,6 +2,7 @@ package syncer_test
 
 import (
 	"os"
+	"syscall"
 	"time"
 
 	"code.cloudfoundry.org/cf-tcp-router/syncer"
@@ -101,6 +102,17 @@ var _ = Describe("Syncer", func() {
 			Eventually(readyChannel).Should(BeClosed())
 			process = ifrit.Invoke(syncerRunner)
 			Eventually(watchChannel).Should(Receive())
+		})
+	})
+
+	Context("when signaled with SIGUSR2", func() {
+		BeforeEach(func() {
+			process = ifrit.Invoke(syncerRunner)
+		})
+		It("does not shut down", func() {
+			process.Signal(syscall.SIGUSR2)
+
+			Consistently(process.Wait()).ShouldNot(Receive())
 		})
 	})
 })

--- a/testrunner/runner.go
+++ b/testrunner/runner.go
@@ -25,7 +25,9 @@ func (args Args) ArgSlice() []string {
 		"-tokenFetchRetryInterval", "1s",
 		"-staleRouteCheckInterval", "5s",
 		"-logLevel=debug",
+		"-syncInterval", "1s",
 		"-routingGroupCheckExit=" + strconv.FormatBool(args.RoutingGroupCheckExit),
+		"-timeFormat", "rfc3339",
 	}
 }
 


### PR DESCRIPTION


- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

Sending a SIGUSR2 will initiate a drain_wait period with tcp-router and trigger it to reconfigure HAProxy's health endpoint to start failing. This will allow loadbalancers to remove it from active service before it shuts down completely.

Updates syncer/monitor/metrics-reporter to ignore SIGUSR2 so they stay up while draining occurs.

Adds logging to metrics-reporter so we can validate it shut down at the appropriate time.

Workflow:
1. SIGUSR2 occurs
2. watcher receives SIGUSR2 and kicks off a goroutine to Drain.
3. watcher resumes normal processing.
4. monitor/syncer/metrics-reporter all ignore the SIGUSR2
5. haproxy receivs the SIGUSR2 but does nothing because we are not in "master-worker" mode. At worst it reloads the config file.
6. the Drain goroutine updates tcp-router to set a mode to force the haproxy health monitor to fail, by setting an environment variable when reloading haproxy
7. the Drain goroutine generates a new config + reloads haproxy
8. the Drain goroutine sleeps for drain_wait
9. the Drain goroutine sends SIGINT to all the tcp-router ifrit group causing all runners to shutdown.

This required reordering the start order for ifrit group members, so that watcher would receive the SIGUSR2 first, rather than the other processes. Additionally, watcher now needs the ability to signal the main process from its goroutine, to ensure the process exits after draining.


Backward Compatibility
---------------
Breaking Change? No. The new property has a sane default, and requires opt-in action to send a SIGUSR2.