### PR TITLE
Fix things lost by the merge conflicts when adding drain support

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -258,7 +258,7 @@ var _ = Describe("Main", func() {
 				Eventually(session.Out, time.Second).Should(gbytes.Say("syncer.stopping"))
 			})
 			It("continues to process events", func() {
-				tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-2", 61000, 120)
+				tcpRouteMapping := models.NewTcpRouteMapping(routerGroupGuid, 5222, "some-ip-2", 61000, 61001, "instance-id", nil, 120, models.ModificationTag{})
 				err := routingApiClient.UpsertTcpRouteMappings([]models.TcpRouteMapping{tcpRouteMapping})
 				Expect(err).ToNot(HaveOccurred())
 

--- a/routing_table/updater_test.go
+++ b/routing_table/updater_test.go
@@ -1127,11 +1127,14 @@ var _ = Describe("Updater", func() {
 		Context("when Sync is called after drain", func() {
 			BeforeEach(func() {
 				tcpMappings := []apimodels.TcpRouteMapping{
-					apimodels.NewTcpRouteMappingWithModificationTag(
+					apimodels.NewTcpRouteMapping(
 						routerGroupGuid,
 						externalPort1,
 						"some-ip-1",
 						61000,
+						61001,
+						"instance-id",
+						nil,
 						ttl,
 						modificationTag,
 					),
@@ -1154,11 +1157,14 @@ var _ = Describe("Updater", func() {
 			Context("when the action is delete", func() {
 				BeforeEach(func() {
 					tcpMappings := []apimodels.TcpRouteMapping{
-						apimodels.NewTcpRouteMappingWithModificationTag(
+						apimodels.NewTcpRouteMapping(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-1",
 							61000,
+							61001,
+							"instance-id",
+							nil,
 							ttl,
 							modificationTag,
 						),
@@ -1182,11 +1188,14 @@ var _ = Describe("Updater", func() {
 					// delete item from the routing table
 					err = updater.HandleEvent(routing_api.TcpEvent{
 						Action: "Delete",
-						TcpRouteMapping: apimodels.NewTcpRouteMappingWithModificationTag(
+						TcpRouteMapping: apimodels.NewTcpRouteMapping(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-1",
 							61000,
+							61001,
+							"instance-id",
+							nil,
 							ttl,
 							modificationTag,
 						),
@@ -1208,11 +1217,14 @@ var _ = Describe("Updater", func() {
 					Expect(drain).To(BeTrue())
 					err = updater.HandleEvent(routing_api.TcpEvent{
 						Action: "Upsert",
-						TcpRouteMapping: apimodels.NewTcpRouteMappingWithModificationTag(
+						TcpRouteMapping: apimodels.NewTcpRouteMapping(
 							routerGroupGuid,
 							externalPort1,
 							"some-ip-1",
 							61000,
+							61001,
+							"instance-id",
+							nil,
 							ttl,
 							modificationTag,
 						),

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -242,7 +242,11 @@ var _ = Describe("Watcher", func() {
 					61000,
 					"some-ip-1",
 					5222,
+					5223,
+					"instance-id",
+					nil,
 					0,
+					models.ModificationTag{},
 				),
 				Action: "Upsert",
 			}
@@ -300,7 +304,11 @@ var _ = Describe("Watcher", func() {
 						61000,
 						"some-ip-1",
 						5222,
+						5223,
+						"instance-id",
+						nil,
 						0,
+						models.ModificationTag{},
 					),
 					Action: "Upsert",
 				}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Re-introduces fixes for go vet problems that were lost when resolving merge conflicts between the tcp router drain support + tls tcp route support.


Backward Compatibility
---------------
Breaking Change? no